### PR TITLE
Modified Postgres Operator to adhere to Guidelines

### DIFF
--- a/postgres-crd-v2/Gopkg.lock
+++ b/postgres-crd-v2/Gopkg.lock
@@ -587,6 +587,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f4fab02764c8b2cb8948986dc45f6918cc99b74293db38e248933efdeff7b488"
+  inputs-digest = "ee8173fb80ccf28f0e480144ea4ad47c426ffb113fd9e8d35f3aab7f7ffc6d4d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/postgres-crd-v2/artifacts/deployment/deployment-minikube.yaml
+++ b/postgres-crd-v2/artifacts/deployment/deployment-minikube.yaml
@@ -24,3 +24,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: postgreses.postgrescontroller.kubeplus
+  annotations:
+    composition: Deployment, Service
+spec:
+  group: postgrescontroller.kubeplus
+  version: v1
+  names:
+    kind: Postgres
+    plural: postgreses
+  scope: Namespaced

--- a/postgres-crd-v2/artifacts/deployment/deployment.yaml
+++ b/postgres-crd-v2/artifacts/deployment/deployment.yaml
@@ -19,3 +19,22 @@ spec:
         image: lmecld/postgres-crd-v2:latest
         imagePullPolicy: Always
         command: [ "/postgres-crd-v2"]
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: postgreses.postgrescontroller.kubeplus
+  annotations:
+    composition: Deployment, Service
+spec:
+  group: postgrescontroller.kubeplus
+  version: v1
+  names:
+    kind: Postgres
+    plural: postgreses
+  scope: Namespaced

--- a/postgres-crd-v2/artifacts/examples/add-db.yaml
+++ b/postgres-crd-v2/artifacts/examples/add-db.yaml
@@ -6,6 +6,6 @@ spec:
   deploymentName: client25
   image: postgres:9.3
   replicas: 1
-  users: [{"username": "devdatta", "password": "pass123"}, 
-          {"username": "pallavi", "password": "pass234"}]
+  users: [{"user": "devdatta", "password": "pass123"}, 
+          {"user": "pallavi", "password": "pass234"}]
   databases: ["moodle", "wordpress", "ecommerce"]

--- a/postgres-crd-v2/artifacts/examples/add-user.yaml
+++ b/postgres-crd-v2/artifacts/examples/add-user.yaml
@@ -6,7 +6,7 @@ spec:
   deploymentName: client25
   image: postgres:9.3
   replicas: 1
-  users: [{"username": "devdatta", "password": "pass123"}, 
-          {"username": "pallavi", "password": "pass234"},
-          {"username": "shrinivas", "password": "pass1"}]
+  users: [{"user": "devdatta", "password": "pass123"}, 
+          {"user": "pallavi", "password": "pass234"},
+          {"user": "shrinivas", "password": "pass1"}]
   databases: ["moodle", "wordpress"]

--- a/postgres-crd-v2/artifacts/examples/crd.yaml
+++ b/postgres-crd-v2/artifacts/examples/crd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: postgreses.postgrescontroller.kubeplus
+  annotations:
+    composition: Deployment, Service
 spec:
   group: postgrescontroller.kubeplus
   version: v1

--- a/postgres-crd-v2/artifacts/examples/delete-db.yaml
+++ b/postgres-crd-v2/artifacts/examples/delete-db.yaml
@@ -6,6 +6,6 @@ spec:
   deploymentName: client25
   image: postgres:9.3
   replicas: 1
-  users: [{"username": "devdatta", "password": "pass123"}, 
-          {"username": "pallavi", "password": "pass234"}]
+  users: [{"user": "devdatta", "password": "pass123"}, 
+          {"user": "pallavi", "password": "pass234"}]
   databases: ["moodle", "wordpress"]

--- a/postgres-crd-v2/artifacts/examples/delete-user.yaml
+++ b/postgres-crd-v2/artifacts/examples/delete-user.yaml
@@ -6,6 +6,6 @@ spec:
   deploymentName: client25
   image: postgres:9.3
   replicas: 1
-  users: [{"username": "devdatta", "password": "pass123"}, 
-          {"username": "pallavi", "password": "pass234"}]
+  users: [{"user": "devdatta", "password": "pass123"}, 
+          {"user": "pallavi", "password": "pass234"}]
   databases: ["moodle", "wordpress"]

--- a/postgres-crd-v2/artifacts/examples/initializeclient.yaml
+++ b/postgres-crd-v2/artifacts/examples/initializeclient.yaml
@@ -6,13 +6,13 @@ spec:
   deploymentName: client25
   image: postgres:9.3
   replicas: 1
-  users: [{"username": "devdatta", "password": "pass123"}, 
-          {"username": "pallavi", "password": "pass234"}]
+  users: [{"user": "devdatta", "password": "pass123"}, 
+          {"user": "pallavi", "password": "pass234"}]
   databases: ["moodle"]
-  initcommands: [ "create table moodle_data1 (items varchar(250));",
-             	  "insert into moodle_data1 (items) values ('Moodle data1');",
-                  "insert into moodle_data1 (items) values ('Moodle data1');",
-                  "insert into moodle_data1 (items) values ('Moodle data2');",
-                  "GRANT ALL PRIVILEGES ON TABLE moodle_data1 TO devdatta;",
-                  "GRANT ALL PRIVILEGES ON TABLE moodle_data1 TO pallavi;"
-                ]
+  commands: [ "create table moodle_data1 (items varchar(250));",
+              "insert into moodle_data1 (items) values ('Moodle data1');",
+              "insert into moodle_data1 (items) values ('Moodle data1');",
+              "insert into moodle_data1 (items) values ('Moodle data2');",
+              "GRANT ALL PRIVILEGES ON TABLE moodle_data1 TO devdatta;",
+              "GRANT ALL PRIVILEGES ON TABLE moodle_data1 TO pallavi;"
+            ]

--- a/postgres-crd-v2/artifacts/examples/modify-password.yaml
+++ b/postgres-crd-v2/artifacts/examples/modify-password.yaml
@@ -6,6 +6,6 @@ spec:
   deploymentName: client25
   image: postgres:9.3
   replicas: 1
-  users: [{"username": "devdatta", "password": "pass123"}, 
-          {"username": "pallavi", "password": "pass123"}]
+  users: [{"user": "devdatta", "password": "pass123"}, 
+          {"user": "pallavi", "password": "pass123"}]
   databases: ["moodle", "wordpress"]

--- a/postgres-crd-v2/main.go
+++ b/postgres-crd-v2/main.go
@@ -63,6 +63,7 @@ func main() {
 		glog.Fatalf("Error building example clientset: %s", err.Error())
 	}
 
+	/*
 	if firstTime {
 		firstTime = false
 		crdclient, err := apiextensionsclientset.NewForConfig(cfg)
@@ -72,6 +73,7 @@ func main() {
 			registerCRD(crdclient)
 		}
 	}
+	*/
 
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
 	exampleInformerFactory := informers.NewSharedInformerFactory(exampleClient, time.Second*30)
@@ -89,7 +91,7 @@ func main() {
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-	firstTime = true
+	//firstTime = true
 }
 
 func registerCRD(crdclient *apiextensionsclientset.Clientset) {

--- a/postgres-crd-v2/pkg/apis/postgrescontroller/v1/types.go
+++ b/postgres-crd-v2/pkg/apis/postgrescontroller/v1/types.go
@@ -24,7 +24,8 @@ import (
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Foo is a specification for a Foo resource
+// Postgres is a specification for a Postgres resource
+// +k8s:openapi-gen=true
 type Postgres struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -33,28 +34,31 @@ type Postgres struct {
 	Status PostgresStatus `json:"status"`
 }
 
+// +k8s:openapi-gen=true
 type UserSpec struct {
-        User string `json:"username"`
+        User string `json:"user"`
         Password string `json:"password"`
 }
 
-// PostgresSpec is the spec for a Foo resource
+// PostgresSpec is the spec for a Postgres resource
+// +k8s:openapi-gen=true
 type PostgresSpec struct {
 	DeploymentName string `json:"deploymentName"`
 	Image string `json:"image"`
 	Replicas       *int32 `json:"replicas"`
 	Users []UserSpec `json:"users"`
 	Databases []string `json:"databases"`
-	Commands []string `json:"initcommands"`
+	Commands []string `json:"commands"`
 }
 
-// FooStatus is the status for a Foo resource
+// PostgresStatus is the status for a Postgres resource
+// +k8s:openapi-gen=true
 type PostgresStatus struct {
 	AvailableReplicas int32 `json:"availableReplicas"`
 	ActionHistory []string `json:"actionHistory"`
 	Users []UserSpec `json:"users"`
 	Databases []string `json:"databases"`
-	VerifyCmd string `json:"verifyCommand"`
+	VerifyCommand string `json:"verifyCommand"`
 	ServiceIP string `json:"serviceIP"`
 	ServicePort string `json:"servicePort"`
 	Status string `json:"status"`
@@ -62,7 +66,7 @@ type PostgresStatus struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// FooList is a list of Foo resources
+// PostgresList is a list of Postgres resources
 type PostgresList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/postgres-crd-v2/pkg/apis/postgrescontroller/v1/zz_generated.deepcopy.go
+++ b/postgres-crd-v2/pkg/apis/postgrescontroller/v1/zz_generated.deepcopy.go
@@ -90,12 +90,8 @@ func (in *PostgresSpec) DeepCopyInto(out *PostgresSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Users != nil {
 		in, out := &in.Users, &out.Users

--- a/postgres-crd-v2/pkg/client/clientset/versioned/clientset.go
+++ b/postgres-crd-v2/pkg/client/clientset/versioned/clientset.go
@@ -20,7 +20,6 @@ package versioned
 
 import (
 	postgrescontrollerv1 "github.com/cloud-ark/kubeplus/postgres-crd-v2/pkg/client/clientset/versioned/typed/postgrescontroller/v1"
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -74,7 +73,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/postgres-crd-v2/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/postgres-crd-v2/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -41,9 +41,10 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
-	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
-	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+	cs := &Clientset{}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
 		watch, err := o.Watch(gvr, ns)
@@ -53,7 +54,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return cs
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a

--- a/postgres-crd-v2/pkg/client/clientset/versioned/typed/postgrescontroller/v1/fake/fake_postgres.go
+++ b/postgres-crd-v2/pkg/client/clientset/versioned/typed/postgrescontroller/v1/fake/fake_postgres.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	postgrescontroller_v1 "github.com/cloud-ark/kubeplus/postgres-crd-v2/pkg/apis/postgrescontroller/v1"
+	postgrescontrollerv1 "github.com/cloud-ark/kubeplus/postgres-crd-v2/pkg/apis/postgrescontroller/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -39,20 +39,20 @@ var postgresesResource = schema.GroupVersionResource{Group: "postgrescontroller.
 var postgresesKind = schema.GroupVersionKind{Group: "postgrescontroller.kubeplus", Version: "v1", Kind: "Postgres"}
 
 // Get takes name of the postgres, and returns the corresponding postgres object, and an error if there is any.
-func (c *FakePostgreses) Get(name string, options v1.GetOptions) (result *postgrescontroller_v1.Postgres, err error) {
+func (c *FakePostgreses) Get(name string, options v1.GetOptions) (result *postgrescontrollerv1.Postgres, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(postgresesResource, c.ns, name), &postgrescontroller_v1.Postgres{})
+		Invokes(testing.NewGetAction(postgresesResource, c.ns, name), &postgrescontrollerv1.Postgres{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*postgrescontroller_v1.Postgres), err
+	return obj.(*postgrescontrollerv1.Postgres), err
 }
 
 // List takes label and field selectors, and returns the list of Postgreses that match those selectors.
-func (c *FakePostgreses) List(opts v1.ListOptions) (result *postgrescontroller_v1.PostgresList, err error) {
+func (c *FakePostgreses) List(opts v1.ListOptions) (result *postgrescontrollerv1.PostgresList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(postgresesResource, postgresesKind, c.ns, opts), &postgrescontroller_v1.PostgresList{})
+		Invokes(testing.NewListAction(postgresesResource, postgresesKind, c.ns, opts), &postgrescontrollerv1.PostgresList{})
 
 	if obj == nil {
 		return nil, err
@@ -62,8 +62,8 @@ func (c *FakePostgreses) List(opts v1.ListOptions) (result *postgrescontroller_v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &postgrescontroller_v1.PostgresList{}
-	for _, item := range obj.(*postgrescontroller_v1.PostgresList).Items {
+	list := &postgrescontrollerv1.PostgresList{ListMeta: obj.(*postgrescontrollerv1.PostgresList).ListMeta}
+	for _, item := range obj.(*postgrescontrollerv1.PostgresList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -79,31 +79,31 @@ func (c *FakePostgreses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 }
 
 // Create takes the representation of a postgres and creates it.  Returns the server's representation of the postgres, and an error, if there is any.
-func (c *FakePostgreses) Create(postgres *postgrescontroller_v1.Postgres) (result *postgrescontroller_v1.Postgres, err error) {
+func (c *FakePostgreses) Create(postgres *postgrescontrollerv1.Postgres) (result *postgrescontrollerv1.Postgres, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(postgresesResource, c.ns, postgres), &postgrescontroller_v1.Postgres{})
+		Invokes(testing.NewCreateAction(postgresesResource, c.ns, postgres), &postgrescontrollerv1.Postgres{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*postgrescontroller_v1.Postgres), err
+	return obj.(*postgrescontrollerv1.Postgres), err
 }
 
 // Update takes the representation of a postgres and updates it. Returns the server's representation of the postgres, and an error, if there is any.
-func (c *FakePostgreses) Update(postgres *postgrescontroller_v1.Postgres) (result *postgrescontroller_v1.Postgres, err error) {
+func (c *FakePostgreses) Update(postgres *postgrescontrollerv1.Postgres) (result *postgrescontrollerv1.Postgres, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(postgresesResource, c.ns, postgres), &postgrescontroller_v1.Postgres{})
+		Invokes(testing.NewUpdateAction(postgresesResource, c.ns, postgres), &postgrescontrollerv1.Postgres{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*postgrescontroller_v1.Postgres), err
+	return obj.(*postgrescontrollerv1.Postgres), err
 }
 
 // Delete takes name of the postgres and deletes it. Returns an error if one occurs.
 func (c *FakePostgreses) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(postgresesResource, c.ns, name), &postgrescontroller_v1.Postgres{})
+		Invokes(testing.NewDeleteAction(postgresesResource, c.ns, name), &postgrescontrollerv1.Postgres{})
 
 	return err
 }
@@ -112,17 +112,17 @@ func (c *FakePostgreses) Delete(name string, options *v1.DeleteOptions) error {
 func (c *FakePostgreses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(postgresesResource, c.ns, listOptions)
 
-	_, err := c.Fake.Invokes(action, &postgrescontroller_v1.PostgresList{})
+	_, err := c.Fake.Invokes(action, &postgrescontrollerv1.PostgresList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched postgres.
-func (c *FakePostgreses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *postgrescontroller_v1.Postgres, err error) {
+func (c *FakePostgreses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *postgrescontrollerv1.Postgres, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(postgresesResource, c.ns, name, data, subresources...), &postgrescontroller_v1.Postgres{})
+		Invokes(testing.NewPatchSubresourceAction(postgresesResource, c.ns, name, data, subresources...), &postgrescontrollerv1.Postgres{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*postgrescontroller_v1.Postgres), err
+	return obj.(*postgrescontrollerv1.Postgres), err
 }

--- a/postgres-crd-v2/pkg/client/clientset/versioned/typed/postgrescontroller/v1/postgres.go
+++ b/postgres-crd-v2/pkg/client/clientset/versioned/typed/postgrescontroller/v1/postgres.go
@@ -21,7 +21,7 @@ package v1
 import (
 	v1 "github.com/cloud-ark/kubeplus/postgres-crd-v2/pkg/apis/postgrescontroller/v1"
 	scheme "github.com/cloud-ark/kubeplus/postgres-crd-v2/pkg/client/clientset/versioned/scheme"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
@@ -37,11 +37,11 @@ type PostgresesGetter interface {
 type PostgresInterface interface {
 	Create(*v1.Postgres) (*v1.Postgres, error)
 	Update(*v1.Postgres) (*v1.Postgres, error)
-	Delete(name string, options *meta_v1.DeleteOptions) error
-	DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error
-	Get(name string, options meta_v1.GetOptions) (*v1.Postgres, error)
-	List(opts meta_v1.ListOptions) (*v1.PostgresList, error)
-	Watch(opts meta_v1.ListOptions) (watch.Interface, error)
+	Delete(name string, options *metav1.DeleteOptions) error
+	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Get(name string, options metav1.GetOptions) (*v1.Postgres, error)
+	List(opts metav1.ListOptions) (*v1.PostgresList, error)
+	Watch(opts metav1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Postgres, err error)
 	PostgresExpansion
 }
@@ -61,7 +61,7 @@ func newPostgreses(c *PostgrescontrollerV1Client, namespace string) *postgreses 
 }
 
 // Get takes name of the postgres, and returns the corresponding postgres object, and an error if there is any.
-func (c *postgreses) Get(name string, options meta_v1.GetOptions) (result *v1.Postgres, err error) {
+func (c *postgreses) Get(name string, options metav1.GetOptions) (result *v1.Postgres, err error) {
 	result = &v1.Postgres{}
 	err = c.client.Get().
 		Namespace(c.ns).
@@ -74,7 +74,7 @@ func (c *postgreses) Get(name string, options meta_v1.GetOptions) (result *v1.Po
 }
 
 // List takes label and field selectors, and returns the list of Postgreses that match those selectors.
-func (c *postgreses) List(opts meta_v1.ListOptions) (result *v1.PostgresList, err error) {
+func (c *postgreses) List(opts metav1.ListOptions) (result *v1.PostgresList, err error) {
 	result = &v1.PostgresList{}
 	err = c.client.Get().
 		Namespace(c.ns).
@@ -86,7 +86,7 @@ func (c *postgreses) List(opts meta_v1.ListOptions) (result *v1.PostgresList, er
 }
 
 // Watch returns a watch.Interface that watches the requested postgreses.
-func (c *postgreses) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *postgreses) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
@@ -121,7 +121,7 @@ func (c *postgreses) Update(postgres *v1.Postgres) (result *v1.Postgres, err err
 }
 
 // Delete takes name of the postgres and deletes it. Returns an error if one occurs.
-func (c *postgreses) Delete(name string, options *meta_v1.DeleteOptions) error {
+func (c *postgreses) Delete(name string, options *metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("postgreses").
@@ -132,7 +132,7 @@ func (c *postgreses) Delete(name string, options *meta_v1.DeleteOptions) error {
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *postgreses) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
+func (c *postgreses) DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
 		Resource("postgreses").

--- a/postgres-crd-v2/pkg/client/informers/externalversions/factory.go
+++ b/postgres-crd-v2/pkg/client/informers/externalversions/factory.go
@@ -32,12 +32,16 @@ import (
 	cache "k8s.io/client-go/tools/cache"
 )
 
+// SharedInformerOption defines the functional option type for SharedInformerFactory.
+type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
+
 type sharedInformerFactory struct {
 	client           versioned.Interface
 	namespace        string
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
 	lock             sync.Mutex
 	defaultResync    time.Duration
+	customResync     map[reflect.Type]time.Duration
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -45,23 +49,62 @@ type sharedInformerFactory struct {
 	startedInformers map[reflect.Type]bool
 }
 
-// NewSharedInformerFactory constructs a new instance of sharedInformerFactory
+// WithCustomResyncConfig sets a custom resync period for the specified informer types.
+func WithCustomResyncConfig(resyncConfig map[v1.Object]time.Duration) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		for k, v := range resyncConfig {
+			factory.customResync[reflect.TypeOf(k)] = v
+		}
+		return factory
+	}
+}
+
+// WithTweakListOptions sets a custom filter on all listers of the configured SharedInformerFactory.
+func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.tweakListOptions = tweakListOptions
+		return factory
+	}
+}
+
+// WithNamespace limits the SharedInformerFactory to the specified namespace.
+func WithNamespace(namespace string) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.namespace = namespace
+		return factory
+	}
+}
+
+// NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
-	return NewFilteredSharedInformerFactory(client, defaultResync, v1.NamespaceAll, nil)
+	return NewSharedInformerFactoryWithOptions(client, defaultResync)
 }
 
 // NewFilteredSharedInformerFactory constructs a new instance of sharedInformerFactory.
 // Listers obtained via this SharedInformerFactory will be subject to the same filters
 // as specified here.
+// Deprecated: Please use NewSharedInformerFactoryWithOptions instead
 func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync time.Duration, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerFactory {
-	return &sharedInformerFactory{
+	return NewSharedInformerFactoryWithOptions(client, defaultResync, WithNamespace(namespace), WithTweakListOptions(tweakListOptions))
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
+func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
+	factory := &sharedInformerFactory{
 		client:           client,
-		namespace:        namespace,
-		tweakListOptions: tweakListOptions,
+		namespace:        v1.NamespaceAll,
 		defaultResync:    defaultResync,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
+		customResync:     make(map[reflect.Type]time.Duration),
 	}
+
+	// Apply all options
+	for _, opt := range options {
+		factory = opt(factory)
+	}
+
+	return factory
 }
 
 // Start initializes all requested informers.
@@ -110,7 +153,13 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+
+	resyncPeriod, exists := f.customResync[informerType]
+	if !exists {
+		resyncPeriod = f.defaultResync
+	}
+
+	informer = newFunc(f.client, resyncPeriod)
 	f.informers[informerType] = informer
 
 	return informer

--- a/postgres-crd-v2/pkg/client/informers/externalversions/postgrescontroller/v1/postgres.go
+++ b/postgres-crd-v2/pkg/client/informers/externalversions/postgrescontroller/v1/postgres.go
@@ -21,11 +21,11 @@ package v1
 import (
 	time "time"
 
-	postgrescontroller_v1 "github.com/cloud-ark/kubeplus/postgres-crd-v2/pkg/apis/postgrescontroller/v1"
+	postgrescontrollerv1 "github.com/cloud-ark/kubeplus/postgres-crd-v2/pkg/apis/postgrescontroller/v1"
 	versioned "github.com/cloud-ark/kubeplus/postgres-crd-v2/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/cloud-ark/kubeplus/postgres-crd-v2/pkg/client/informers/externalversions/internalinterfaces"
 	v1 "github.com/cloud-ark/kubeplus/postgres-crd-v2/pkg/client/listers/postgrescontroller/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
@@ -57,20 +57,20 @@ func NewPostgresInformer(client versioned.Interface, namespace string, resyncPer
 func NewFilteredPostgresInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
-			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
 				return client.PostgrescontrollerV1().Postgreses(namespace).List(options)
 			},
-			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
 				return client.PostgrescontrollerV1().Postgreses(namespace).Watch(options)
 			},
 		},
-		&postgrescontroller_v1.Postgres{},
+		&postgrescontrollerv1.Postgres{},
 		resyncPeriod,
 		indexers,
 	)
@@ -81,7 +81,7 @@ func (f *postgresInformer) defaultInformer(client versioned.Interface, resyncPer
 }
 
 func (f *postgresInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&postgrescontroller_v1.Postgres{}, f.defaultInformer)
+	return f.factory.InformerFor(&postgrescontrollerv1.Postgres{}, f.defaultInformer)
 }
 
 func (f *postgresInformer) Lister() v1.PostgresLister {

--- a/postgres-crd-v2/postgres-crd-v2-chart/generated.json
+++ b/postgres-crd-v2/postgres-crd-v2-chart/generated.json
@@ -1,0 +1,137 @@
+{
+  "swagger": "2.0",
+  "info": {
+   "title": "OpenAPI Doc Generator",
+   "version": "0.0.1"
+  },
+  "paths": {},
+  "definitions": {
+   "typedir.Postgres": {
+    "description": "Postgres is a specification for a Postgres resource",
+    "required": [
+     "spec",
+     "status"
+    ],
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "spec": {
+      "$ref": "#/definitions/typedir.PostgresSpec"
+     },
+     "status": {
+      "$ref": "#/definitions/typedir.PostgresStatus"
+     }
+    }
+   },
+   "typedir.PostgresSpec": {
+    "description": "PostgresSpec is the spec for a Postgres resource",
+    "required": [
+     "deploymentName",
+     "image",
+     "replicas",
+     "users",
+     "databases",
+     "commands"
+    ],
+    "properties": {
+     "commands": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "databases": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "deploymentName": {
+      "type": "string"
+     },
+     "image": {
+      "type": "string"
+     },
+     "replicas": {
+      "type": "integer",
+      "format": "int32"
+     },
+     "users": {
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/typedir.UserSpec"
+      }
+     }
+    }
+   },
+   "typedir.PostgresStatus": {
+    "description": "PostgresStatus is the status for a Postgres resource",
+    "required": [
+     "availableReplicas",
+     "actionHistory",
+     "users",
+     "databases",
+     "verifyCommand",
+     "serviceIP",
+     "servicePort",
+     "status"
+    ],
+    "properties": {
+     "actionHistory": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "availableReplicas": {
+      "type": "integer",
+      "format": "int32"
+     },
+     "databases": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "serviceIP": {
+      "type": "string"
+     },
+     "servicePort": {
+      "type": "string"
+     },
+     "status": {
+      "type": "string"
+     },
+     "users": {
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/typedir.UserSpec"
+      }
+     },
+     "verifyCommand": {
+      "type": "string"
+     }
+    }
+   },
+   "typedir.UserSpec": {
+    "required": [
+     "user",
+     "password"
+    ],
+    "properties": {
+     "password": {
+      "type": "string"
+     },
+     "user": {
+      "type": "string"
+     }
+    }
+   }
+  }
+ }

--- a/postgres-crd-v2/postgres-crd-v2-chart/templates/deployment.yaml
+++ b/postgres-crd-v2/postgres-crd-v2-chart/templates/deployment.yaml
@@ -19,3 +19,22 @@ spec:
         image: lmecld/postgres-crd-v2:latest
         imagePullPolicy: Always
         command: [ "/postgres-crd-v2"]
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: postgreses.postgrescontroller.kubeplus
+  annotations:
+    composition: Deployment, Service
+spec:
+  group: postgrescontroller.kubeplus
+  version: v1
+  names:
+    kind: Postgres
+    plural: postgreses
+  scope: Namespaced


### PR DESCRIPTION
1. types.go now uses kube-openapi annotations
2. field names in types.go modified to pass kube-openapi
   validation check
3. generated.json included in postgres-crd-v2-chart is
   the OpenAPI documentation spec for the types managed
   by this Operator. It is generated through our doc-generation
   tool.
4. controller.go now setting OwnerReference on the
   Deployment and Service objects that it creates for each
   Postgres object