### PR TITLE
openapi-spec-generator updates

### DIFF
--- a/openapi-spec-generator/build-openapi-spec.sh
+++ b/openapi-spec-generator/build-openapi-spec.sh
@@ -1,18 +1,27 @@
 #!/bin/bash
 
 if [ "$#" -ne 1 ]; then
-   echo "./build-openapi-doc.sh <relative path to the directory containing types.go>"
+   echo "./build-openapi-doc.sh <Path to the directory containing types.go>"
    exit
 fi
 
 cp $1/types.go typedir/.
 cd typedir
-sed s'#metav1.ObjectMeta#//metav1.ObjectMeta#'g types.go > types1.go
-sed s'#metav1.ListMeta#//metav1.ListMeta#'g types1.go > types2.go
+sed -E '/PersistentVolumeClaim|Affinity|ObjectMeta|ListMeta|LocalObjectReference|Time/s/^/\/\//' types.go > types1.go
+
 mv types.go types.go.orig
-cp types2.go types.go
+cp types1.go types.go
 cd ..
-go run openapi-gen.go
-go run builder.go
-cp openapispec.json $1
-echo "OpenAPI Spec file generated and copied to $1"
+op1=`go run openapi-gen.go`
+op2=`go run builder.go`
+
+echo "$op1"
+
+if [[ $op1 = *"API rule violation"* ]]; then
+   echo FAIL
+   echo "API rule violation"
+else
+   echo OK
+   echo "OpenAPI Spec file generated and copied to $1"
+   cp openapispec.json $1
+fi


### PR DESCRIPTION
Improvement to the build-openapi-spec script toi:
- commenting out several more kubernetes native types
  that don't seem to have kube-openapi spec annotations.
  Note that this commenting is only done so as to allow
  kube-openapi to generate OpenAPI Spec for our custom types
- Added error checking