### PR TITLE
README updates and added placholder DeleteFunc

### DIFF
--- a/postgres-crd-v2/Gopkg.lock
+++ b/postgres-crd-v2/Gopkg.lock
@@ -14,41 +14,10 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  name = "github.com/coreos/etcd"
-  packages = [
-    "client",
-    "pkg/pathutil",
-    "pkg/srv",
-    "pkg/types",
-    "version"
-  ]
-  revision = "fca8add78a9d926166eb739b8e4a124434025ba3"
-  version = "v3.3.9"
-
-[[projects]]
-  name = "github.com/coreos/go-semver"
-  packages = ["semver"]
-  revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
-  version = "v0.2.0"
-
-[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/dsnet/compress"
-  packages = [
-    ".",
-    "bzip2",
-    "bzip2/internal/sais",
-    "internal",
-    "internal/errors",
-    "internal/prefix"
-  ]
-  revision = "cc9eb1d7ad760af14e8f918698f745e80377af4f"
 
 [[projects]]
   name = "github.com/emicklei/go-restful"
@@ -218,12 +187,6 @@
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
-  name = "github.com/mholt/archiver"
-  packages = ["."]
-  revision = "cdc68dd1f170b8dfc1a0d2231b5bb0967ed67006"
-  version = "v2.0"
-
-[[projects]]
   name = "github.com/modern-go/concurrent"
   packages = ["."]
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
@@ -234,12 +197,6 @@
   packages = ["."]
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/nwaples/rardecode"
-  packages = ["."]
-  revision = "e06696f847aeda6f39a8f0b7cdff193b7690aef6"
 
 [[projects]]
   branch = "master"
@@ -258,23 +215,6 @@
   packages = ["."]
   revision = "9a97c102cda95a86cec2345a6f09f55a939babf5"
   version = "v1.0.2"
-
-[[projects]]
-  name = "github.com/ugorji/go"
-  packages = ["codec"]
-  revision = "b4c50a2b199d93b13dc15e78929cfb23bfdf21ab"
-  version = "v1.1.1"
-
-[[projects]]
-  name = "github.com/ulikunitz/xz"
-  packages = [
-    ".",
-    "internal/hash",
-    "internal/xlog",
-    "lzma"
-  ]
-  revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
-  version = "v0.5.4"
 
 [[projects]]
   branch = "master"
@@ -641,6 +581,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e6017153d81fbb820f213368b919c8c4c44acface5783b2a46262715cbf54a11"
+  inputs-digest = "d7258b9f9a08b45340df56aa6ad8b0f726e498c75374a0aac45b98e7cf7d8e8a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/postgres-crd-v2/README.rst
+++ b/postgres-crd-v2/README.rst
@@ -86,7 +86,7 @@ Actual steps:
 
 2) Install dependencies:
 
-   - cd $GOPATH/src/github.com/cloud-ark/kubeplus
+   - cd $GOPATH/src/github.com/cloud-ark/kubeplus/postgres-crd-v2
 
    - dep ensure
 
@@ -94,23 +94,26 @@ Actual steps:
 
    - cd $GOPATH/src/github.com/cloud-ark/kubeplus/postgres-crd-v2
 
-   - Run from Host machine:
+   - Follow either one of the following 3 options:
+
+     A] Run from Host machine:
      
-     - go run *.go -kubeconfig=$HOME/.kube/config
+        - export HOST_IP=`minikube ip`
+        - go run *.go -kubeconfig=$HOME/.kube/config
 
-   - Deploy the controller as a Deployment in the cluster using
-     controller Docker image built locally
+     B] Deploy the controller as a Deployment in the cluster using
+        controller Docker image built locally
      
-     - ./build-local-deploy-artifacts.sh
+         - ./build-local-deploy-artifacts.sh
      
-     - cd artifacts/deployment
+         - cd artifacts/deployment
 
-     - kubectl create -f deployment-minikube.yaml
+         - kubectl create -f deployment-minikube.yaml
 
-   - Deploy the controller with Helm chart (here the controller
-     Docker image is pulled from Docker hub)
+     C] Deploy the controller with Helm chart (here the controller
+        Docker image is pulled from Docker hub)
 
-     - helm install ./postgres-crd-v2-chart
+        - helm install ./postgres-crd-v2-chart
 
 4) In another shell window check that Postgres CRD has been registered.
 

--- a/postgres-crd-v2/controller.go
+++ b/postgres-crd-v2/controller.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"os"
 
 	"database/sql"
 	_ "github.com/lib/pq"
@@ -146,6 +147,13 @@ func NewController(
 				controller.enqueueFoo(new)
 			}
 		},
+		/*
+		DeleteFunc: func(obj interface{}) {
+		        _, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			if err == nil {
+			   controller.deleteFoo(obj)
+			}
+		},*/
 	})
 	return controller
 }
@@ -294,6 +302,16 @@ func (c *Controller) handleObject(obj interface{}) {
 	}
 }
 
+
+func (c *Controller) deleteFoo(obj interface{}) {
+
+	fmt.Println("Inside delete Foo")
+
+	var err error
+	if _, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+	   panic(err)
+	}
+}
 
 // syncHandler compares the actual state with the desired, and attempts to
 // converge the two. It then updates the Status block of the Foo resource


### PR DESCRIPTION
The purpose of DeleteFunc is to experiment with
'ordered' delete of Objects - Deployment and Service.
The ordering does not really matter this CRD, but
there was a thread on kubernetes-dev[1] about how
to perform ordered deletes. Our view is that just
OwnerReferences does not help with the order. Required
order needs to be enforced in the delete handler.
The placeholder delete handler needs to be fleshed
out to implement order deletes. Note that the DeleteFunc
EventHandlerSetup is commented out right now.
Once the delete handler is fleshed out, uncomment it.

Right now without the delete handler, Kubernetes correctly
deletes all the child Objects when Postgres instance is deleted.
Only that it does not do this in any specific order.

[1] https://groups.google.com/forum/#!topic/kubernetes-dev/1QnYSPGn85M