### PR TITLE
Added example of non-kubectl access

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,12 +34,16 @@ and enables creating application Platforms as Code. Using KubePlus Platform Kit,
   introduced by the installed Operators.
 
 We bring consistency of usage across multiple Operators with our Operator development guidelines_.
-Teams can Build their Own PaaSes on Kubernetes selecting required Operators 
-from our `repository of certified Operators`__ packaged as Helm charts.
+Teams can Build their Own PaaSes on Kubernetes selecting required Operators packaged as Helm charts.
+
+We are maintaining a `repository of Operators`__ that follow the guidelines. You can use Operators
+from it or create your own Operator and use it with KubePlus. We can also help with checking
+your Operators against the guidelines. Just open an issue on the repository with link to your Operator
+code and we will provide you feedback on it.
 
 .. _guidelines: https://github.com/cloud-ark/kubeplus/blob/master/Guidelines.md
 
-.. _repository: https://github.com/cloud-ark/operatorcharts/blob/master/index.yaml
+.. _repository: https://github.com/cloud-ark/operatorcharts/
 
 __ repository_
 

--- a/examples/non-kubectl-access/steps.txt
+++ b/examples/non-kubectl-access/steps.txt
@@ -1,0 +1,41 @@
+Use curl to interact with KubePlus
+-----------------------------------
+
+1. Deploy Postgres Operator (follow steps in ../postgres/steps.txt)
+
+2. Start Proxy
+   - kubectl proxy --port=8080 &
+
+3. Find out information about Postgres Custom Kind
+   - curl "http://localhost:8080/apis/kubeplus.cloudark.io/v1/explain?kind=Postgres" | python -m json.tool
+
+   - curl "http://localhost:8080/apis/kubeplus.cloudark.io/v1/explain?kind=Postgres.PostgresSpec" | python -m json.tool
+
+   - curl "http://localhost:8080/apis/kubeplus.cloudark.io/v1/explain?kind=Postgres.PostgresSpec.UserSpec" | python -m json.tool
+
+
+
+Use Python to interact with KubePlus
+-------------------------------------
+
+1. Deploy Postgres Operator (follow steps in ../postgres/steps.txt)
+
+2. Start Proxy
+   - kubectl proxy --port=8080 &
+
+3. Create Python VirtualEnv
+   - virtualenv -p python3 python3venv
+
+4. Start virtualenv
+   - source python3venv/bin/activate
+
+5. Install requests library
+   - pip install requests
+
+6. Find out information about Postgres Custom Kind
+   - python
+   >>> import requests
+   >>> r = requests.get("http://localhost:8080/apis/kubeplus.cloudark.io/v1/explain?kind=Postgres")
+   >>> r.json()
+   
+

--- a/examples/postgres/steps.txt
+++ b/examples/postgres/steps.txt
@@ -41,9 +41,9 @@ Steps:
     - kubectl get operators
     - kubectl describe operators postgres-operator
     - kubectl describe customresourcedefinition postgreses.postgrescontroller.kubeplus
-    - kubectl get --raw "/apis/kubeplus.cloudark.io/v1/explain?kind=Postgres" | python -m jston.tool
+    - kubectl get --raw "/apis/kubeplus.cloudark.io/v1/explain?kind=Postgres" | python -m json.tool
       --> You should see OpenAPI Spec for Postgres custom kind as output
-    - kubectl get --raw "/apis/kubeplus.cloudark.io/v1/explain?kind=Postgres.PostgresSpec" | python -m jston.tool
+    - kubectl get --raw "/apis/kubeplus.cloudark.io/v1/explain?kind=Postgres.PostgresSpec" | python -m json.tool
 
 12) Deploy Postgres1 instance
     - kubectl create -f postgres1.yaml


### PR DESCRIPTION
Partially-Fixes: https://github.com/cloud-ark/kubeplus/issues/126

The example added in this patch requires proxy to be started on the cluster.
We should also add example that does not require proxy.