### PR TITLE
Updated Moodle example

### DIFF
--- a/examples/moodle/moodle1.yaml
+++ b/examples/moodle/moodle1.yaml
@@ -4,6 +4,5 @@ metadata:
   name: moodle1
 spec:
   name: moodle1
-  adminPassword: password1
   plugins: ["profilecohort"]
 

--- a/examples/moodle/moodle2.yaml
+++ b/examples/moodle/moodle2.yaml
@@ -4,6 +4,5 @@ metadata:
   name: moodle2
 spec:
   name: moodle2
-  adminPassword: password1
   plugins: ["profilecohort"]
 

--- a/examples/moodle/steps.txt
+++ b/examples/moodle/steps.txt
@@ -14,7 +14,7 @@ an example of how to specify installation of additional plugins on an existing M
 Setup:
 -------
 - Download Minikube, download Helm
-  - The example has been tested on minikube-0.25, minikube-0.28, minikube-0.30
+  - The example has been tested on minikube-0.25, minikube-0.28, minikube-0.30 and helm version 2.11.0
 
 Steps:
 -------
@@ -59,18 +59,16 @@ Steps:
     - Next create Moodle instance
       - kubectl create -f moodle1.yaml
       - kubectl get pods (It will take about 5/6 minutes for Moodle Pod to become ready)
-    - Once Moodle Pod is ready, do following:
-    - Login to Moodle Instance
+    - Once Moodle Pod is ready, login to the Moodle instance
       - Update /etc/hosts with <minikube-ip> moodle1. Example:
         - 192.168.99.100 moodle1
         - You can find minikube ip using: "minikube ip" command
-    - Check Moodle1 instance
-      - kubectl describe moodle moodle1
-        - The URL of Moodle instance should be available from Status field from output of above describe command.
-        - Open the URL in the browser
-        - Login using 'admin' and 'password1' as login credentials (these are specified in moodle1.yaml)
-    - Find composition tree of Moodle1 instance
-      - kubectl get --raw "/apis/kubeplus.cloudark.io/v1/composition?kind=Moodle&instance=moodle1" | python -m json.tool
+      - Retrieve Moodle instance's admin password
+	- kubectl describe moodles moodle1
+        - kubectl get secret moodle1 -o jsonpath="{.data.adminPassword}" | base64 --decode
+          - Secret name is available in the output of 'describe' command
+      - Navigate to the URL of moodle1 instance (available in the output of 'describe' command)
+        - Login using 'admin' as username and password retrieved earlier from secret
     - Check installed plugins
       - As part of creating moodle instance, we install the 'profilecohort' plugin.
         Check the custom resource specification moodle1.yaml to see this definition.
@@ -80,11 +78,17 @@ Steps:
         - Navigate to -> Administration -> Plugins -> Plugins Overview
         - You should see 'profilecohort' plugin in the 'Additional plugins' list
 
+    - Find composition tree of Moodle1 instance
+      - kubectl get --raw "/apis/kubeplus.cloudark.io/v1/composition?kind=Moodle&instance=moodle1" | python -m json.tool
+
+
 13) Update Moodle Deployment to install new Plugin
     - We will install 'wiris' plugin on 'moodle1' Moodle instance
     - kubectl apply -f update-moodle1.yaml
 
-    - Once moodle1 instance is Ready, refresh the URL
+    - Wait for Moodle instance to become Ready
+      - kubectl describe moodle moodle1
+      - Once moodle1 instance is Ready, refresh the URL in the browser
 
     - You will see a message to update Moodle database for 'wiris' plugin
     - Select that option to complete Plugin installation
@@ -106,7 +110,8 @@ Steps:
       - kubectl describe moodle moodle2
         - The URL of Moodle instance should be available from Status field from output of above command
         - Open the URL in the browser
-          - Login using 'admin' and 'password1' as login credentials
+          - Login using 'admin' as username and retrieve password from moodle2 secret as described 
+            in step 12.
 
 
 Troubleshooting

--- a/examples/moodle/update-moodle1.yaml
+++ b/examples/moodle/update-moodle1.yaml
@@ -4,6 +4,5 @@ metadata:
   name: moodle1
 spec:
   name: moodle1
-  adminPassword: password1
   plugins: ["profilecohort", "wiris"]
 

--- a/examples/moodle/update-moodle2.yaml
+++ b/examples/moodle/update-moodle2.yaml
@@ -4,6 +4,5 @@ metadata:
   name: moodle2
 spec:
   name: moodle2
-  adminPassword: password1
   plugins: ["profilecohort", "wiris"]
 


### PR DESCRIPTION
- Updated the example specs to remove adminPassword.
  It is now being created by the Moodle Operator and
  stored as Kubernetes Secret.
- Updated the steps to retrieve the password from
  Kubernetes Secret.