### PR TITLE
ETCD Helper package

### DIFF
--- a/etcd_helper/etcdfuncs.go
+++ b/etcd_helper/etcdfuncs.go
@@ -1,0 +1,181 @@
+package etcd_helper
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/coreos/etcd/client"
+)
+
+// Etcdreader ...
+// Performs read operations on an Etcd database
+type Etcdreader struct {
+	EtcdServiceURL string
+}
+
+// Etcdwriter ...
+// Performs write operations on an Etcd database
+type Etcdwriter struct {
+	EtcdServiceURL string
+}
+
+// getClient
+// Internal helper method creating a connection to an etcd database
+// at a specific etcd URL.
+func getClient(etcdServiceURL string) (client.Client, error) {
+	cfg := client.Config{
+		Endpoints: []string{etcdServiceURL},
+		Transport: client.DefaultTransport,
+	}
+	c, err := client.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return c, err
+}
+
+// Get ...
+// Method to Get a single value for a key
+func (o Etcdreader) Get(resourceKey string) (string, error) {
+	c, err := getClient(o.EtcdServiceURL)
+	if err != nil {
+		return "", err
+	}
+	kapi := client.NewKeysAPI(c)
+
+	resp, err := kapi.Get(context.Background(), resourceKey, nil)
+	if err != nil {
+		return "", err
+	}
+	// (danielpygo): TODO
+	// ADD LOGLEVEL ...
+	return resp.Node.Value, nil
+}
+
+// GetList ...
+// Method to Get a list of values for a key
+func (o Etcdreader) GetList(resourceKey string) ([]string, error) {
+	c, err := getClient(o.EtcdServiceURL)
+	kapi := client.NewKeysAPI(c)
+
+	var currentListString string
+	var currentList []string
+
+	resp, err1 := kapi.Get(context.Background(), resourceKey, nil)
+	if err1 != nil {
+		return nil, err1
+	} else {
+		currentListString = resp.Node.Value
+		if err = json.Unmarshal([]byte(currentListString), &currentList); err != nil {
+			return nil, err
+		}
+	}
+	return currentList, nil
+}
+
+// Store ...
+// Method to Store a value for a key
+func (o Etcdwriter) Store(resourceKey, resourceData string) error {
+	c, err := getClient(o.EtcdServiceURL)
+	if err != nil {
+		log.Fatal(err)
+		return err
+
+	}
+	kapi := client.NewKeysAPI(c)
+
+	_, err = kapi.Set(context.Background(), resourceKey, resourceData, nil)
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	return nil
+}
+
+// StoreList ...
+// Method to Store a list into a key
+func (o Etcdwriter) StoreList(resourceKey string, dataList []string) error {
+	c, err := getClient(o.EtcdServiceURL)
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	kapi := client.NewKeysAPI(c)
+
+	jsonList, err := json.Marshal(&dataList)
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	resourceVal := string(jsonList)
+
+	_, err = kapi.Set(context.Background(), resourceKey, resourceVal, nil)
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	return nil
+}
+
+// Delete ...
+// Method to Delete a key/val pair from a list of strings or a single string
+func (o Etcdwriter) Delete(resourceKey, resourceValue string) error {
+	c, err := getClient(o.EtcdServiceURL)
+	if err != nil {
+		return err
+	}
+	kapi := client.NewKeysAPI(c)
+
+	var r Etcdreader
+	r.EtcdServiceURL = o.EtcdServiceURL
+	valueList, err := r.GetList(resourceKey)
+	if err == nil {
+		if len(valueList) == 1 {
+			//When using StoreList for one elem, or if a List gets reduced to one elem
+			//We need to try and delete both the key and val with kapi.Delete Or else
+			// resourceKey gets set to "null"
+			return o.deleteSingleElem(resourceKey, "[\""+resourceValue+"\"]", kapi)
+		}
+		var newList []string
+		for _, val := range valueList {
+			if val != resourceValue {
+				newList = append(newList, val)
+			}
+		}
+		jsonValueList, err := json.Marshal(&newList)
+
+		if err != nil {
+			log.Fatal(err)
+			return err
+		}
+		newResourceValue := string(jsonValueList)
+
+		_, err = kapi.Set(context.Background(), resourceKey, newResourceValue, nil)
+		if err != nil {
+			log.Fatal(err)
+			return err
+		}
+	} else {
+		_, err := r.Get(resourceKey)
+		if err != nil {
+			log.Fatal(err)
+			return err
+		}
+		return o.deleteSingleElem(resourceKey, resourceValue, kapi)
+	}
+	return nil
+}
+
+// Delete ...
+// Method to Delete a single key/value pair
+// If it is successful key gets deleted as well.
+func (o Etcdwriter) deleteSingleElem(resourceKey, resourceValue string, kapi client.KeysAPI) error {
+	//Deletes the key and val, iff value is val
+	_, err := kapi.Delete(context.Background(), resourceKey, &client.DeleteOptions{PrevValue: resourceValue})
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	return nil
+}

--- a/etcd_helper/tests/Dockerfile
+++ b/etcd_helper/tests/Dockerfile
@@ -1,0 +1,3 @@
+FROM fedora
+ADD etcdhelper.test /
+ENTRYPOINT ["/etcdhelper.test"]

--- a/etcd_helper/tests/README.md
+++ b/etcd_helper/tests/README.md
@@ -1,0 +1,4 @@
+# TESTING STEPS
+...kubeplus/etcd_helper/tests $ ./build.sh
+...kubeplus/etcd_helper/tests $ kubectl create -f testpod.yaml
+...kubeplus/etcd_helper/tests $ kubectl logs etcd-helper etcd-tester

--- a/etcd_helper/tests/build.sh
+++ b/etcd_helper/tests/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export GOOS=linux;
+cd ..
+go test -c ./tests -o etcdhelper.test
+cd tests
+mv ../etcdhelper.test ./
+docker build -t etcd-helper-tests:latest ./

--- a/etcd_helper/tests/etcd_test.go
+++ b/etcd_helper/tests/etcd_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/danielpygo/kubeplus/etcd_helper"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	rdr  etcd_helper.Etcdreader
+	wrtr etcd_helper.Etcdwriter
+)
+
+func init() {
+	rdr.EtcdServiceURL = "http://localhost:2379"
+	wrtr.EtcdServiceURL = "http://localhost:2379"
+}
+
+func TestGet(t *testing.T) {
+	err := wrtr.Store("postgres", "THIS IS SOME DATA")
+	if err != nil {
+		fmt.Printf("Err: %s\n", err)
+	}
+	str, err := rdr.Get("postgres")
+	if err != nil {
+		fmt.Printf("Err: %s\n", err)
+	}
+	assert.Equal(t, str, "THIS IS SOME DATA", "A simple Post and Get of one item")
+}
+func TestGetList(t *testing.T) {
+	dataList := []string{"database1", "database2", "database3"}
+	err := wrtr.StoreList("postgres1", dataList)
+	if err != nil {
+		fmt.Printf("Err: %s\n", err)
+	}
+	strSlice, err := rdr.GetList("postgres1")
+	if err != nil {
+		fmt.Printf("Err: %s\n", err)
+	}
+	assert.Equal(t, strSlice, dataList, "A simple Post and Get of an array of dataItems")
+}
+
+func TestDeleteFromList(t *testing.T) {
+	dataList := []string{"database1", "database2", "database3"}
+	err := wrtr.StoreList("postgres2", dataList)
+	if err != nil {
+		fmt.Printf("Err %s\n", err)
+	}
+	err = wrtr.Delete("postgres2", "database3")
+	if err != nil {
+		fmt.Printf("Err: %s\n", err)
+	}
+	strSlice, err := rdr.GetList("postgres2")
+	if err != nil {
+		fmt.Printf("Err: %s\n", err)
+	}
+	expectedDataList := []string{"database1", "database2"}
+	assert.Equal(t, expectedDataList, strSlice, "A simple Delete operation")
+}
+
+func TestDeleteKey(t *testing.T) {
+	err := wrtr.Store("postgres3", "somedata")
+	if err != nil {
+		fmt.Printf("Err: %s\n", err)
+	}
+	str, err := rdr.Get("postgres3")
+
+	assert.Equal(t, str, "somedata", "Ensure it was stored")
+
+	err = wrtr.Delete("postgres3", "somedata")
+	if err != nil {
+		fmt.Printf("Err: %s\n", err)
+	}
+	str, err = rdr.Get("postgres3")
+
+	assert.Equal(t, err.Error()[0:18], "100: Key not found", "The key should be deleted")
+	assert.Equal(t, "", str, "A Delete of one key/val pair stored using Store")
+}
+
+func TestDelete3(t *testing.T) {
+	dataList := []string{"database1"}
+	wrtr.StoreList("postgres4", dataList)
+
+	_, err := rdr.Get("postgres4")
+	if err != nil {
+		fmt.Printf("Err: %s\n", err)
+	}
+	err = wrtr.Delete("postgres4", "database1")
+	if err != nil {
+		fmt.Printf("Err: %s\n", err)
+	}
+	str, err := rdr.Get("postgres4")
+	assert.Equal(t, err.Error()[0:18], "100: Key not found", "The key should be deleted")
+	assert.Equal(t, "", str, "A Delete of a key/val pair stored as a list with StoreList")
+}

--- a/etcd_helper/tests/testpod.yaml
+++ b/etcd_helper/tests/testpod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd-helper
+  namespace: default
+spec:
+  restartPolicy: Never
+  containers:
+  - name: etcd
+    image: quay.io/coreos/etcd:v3.2.18
+  - name: etcd-tester
+    image: etcd-helper-tests:latest
+    imagePullPolicy: IfNotPresent
+    command: [ "/etcdhelper.test"]


### PR DESCRIPTION
- Supports: Get, GetList, Store, StoreList, Delete
- Import it as: github.com/cloud-ark/kubeplus/etcd_helper"

This PR includes EtcdHelper package, made to be used by other packages that need to communicate with etcd database.