### PR TITLE
Thorough testing and fixed import

### DIFF
--- a/etcd_helper/tests/etcd_test.go
+++ b/etcd_helper/tests/etcd_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/danielpygo/kubeplus/etcd_helper"
+	"github.com/cloud-ark/kubeplus/etcd_helper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,10 +22,12 @@ func TestGet(t *testing.T) {
 	err := wrtr.Store("postgres", "THIS IS SOME DATA")
 	if err != nil {
 		fmt.Printf("Err: %s\n", err)
+		t.Fail()
 	}
 	str, err := rdr.Get("postgres")
 	if err != nil {
 		fmt.Printf("Err: %s\n", err)
+		t.Fail()
 	}
 	assert.Equal(t, str, "THIS IS SOME DATA", "A simple Post and Get of one item")
 }
@@ -34,10 +36,12 @@ func TestGetList(t *testing.T) {
 	err := wrtr.StoreList("postgres1", dataList)
 	if err != nil {
 		fmt.Printf("Err: %s\n", err)
+		t.Fail()
 	}
 	strSlice, err := rdr.GetList("postgres1")
 	if err != nil {
 		fmt.Printf("Err: %s\n", err)
+		t.Fail()
 	}
 	assert.Equal(t, strSlice, dataList, "A simple Post and Get of an array of dataItems")
 }
@@ -47,14 +51,17 @@ func TestDeleteFromList(t *testing.T) {
 	err := wrtr.StoreList("postgres2", dataList)
 	if err != nil {
 		fmt.Printf("Err %s\n", err)
+		t.Fail()
 	}
 	err = wrtr.Delete("postgres2", "database3")
 	if err != nil {
 		fmt.Printf("Err: %s\n", err)
+		t.Fail()
 	}
 	strSlice, err := rdr.GetList("postgres2")
 	if err != nil {
 		fmt.Printf("Err: %s\n", err)
+		t.Fail()
 	}
 	expectedDataList := []string{"database1", "database2"}
 	assert.Equal(t, expectedDataList, strSlice, "A simple Delete operation")
@@ -64,6 +71,7 @@ func TestDeleteKey(t *testing.T) {
 	err := wrtr.Store("postgres3", "somedata")
 	if err != nil {
 		fmt.Printf("Err: %s\n", err)
+		t.Fail()
 	}
 	str, err := rdr.Get("postgres3")
 
@@ -72,6 +80,7 @@ func TestDeleteKey(t *testing.T) {
 	err = wrtr.Delete("postgres3", "somedata")
 	if err != nil {
 		fmt.Printf("Err: %s\n", err)
+		t.Fail()
 	}
 	str, err = rdr.Get("postgres3")
 
@@ -86,10 +95,12 @@ func TestDeleteSingleValWithKey(t *testing.T) {
 	_, err := rdr.Get("postgres4")
 	if err != nil {
 		fmt.Printf("Err: %s\n", err)
+		t.Fail()
 	}
 	err = wrtr.Delete("postgres4", "database1")
 	if err != nil {
 		fmt.Printf("Err: %s\n", err)
+		t.Fail()
 	}
 	str, err := rdr.Get("postgres4")
 	assert.Equal(t, err.Error()[0:18], "100: Key not found", "The key should be deleted")


### PR DESCRIPTION
- Fixes Issue: https://github.com/cloud-ark/kubeplus/issues/223
- Using t.fail() inside of err!=nil blocks
- also import is now correct `github.com/cloud-ark/kubeplus/etcd_helper`
