### PR TITLE
Removed dependency on operator-discovery-helper

### DIFF
--- a/deploy/rc.yaml
+++ b/deploy/rc.yaml
@@ -26,11 +26,11 @@ spec:
 #        image: lmecld/operator-deployer:latest
 #        imagePullPolicy: IfNotPresent
 #        command: [ "/operator-deployer"]
-      - name: operator-discovery-helper
-        image: lmecld/operator-discovery-helper:0.3.0
-        imagePullPolicy: Always
-        command: [ "/operator-discovery-helper"]
+#      - name: operator-discovery-helper
+#        image: lmecld/operator-discovery-helper:0.3.0
+#        imagePullPolicy: Always
+#        command: [ "/operator-discovery-helper"]
       - name: kube-discovery-apiserver
-        image: lmecld/kube-discovery-apiserver:0.4.1
+        image: lmecld/kube-discovery-apiserver:0.4.2
         imagePullPolicy: Always
         command: [ "/kube-discovery-apiserver", "--etcd-servers=http://localhost:2379" ]


### PR DESCRIPTION
operator-discovery-helper module was written as a bridge
between kubediscovery and the crds available in the cluster.
operator-discovery-helper 'discovered' available crds and
shared them with kubediscovery through etcd (different from
the control plane's own etcd).

kubediscovery has now been updated to list crds itself by grafting
the appropriate operator-discovery-helper code inside it.

We are not yet removing etcd container deployment as part of rc.yaml
as it can be used for storing the composition graph.
If we decide to not store the composition graph then we can remove
etcd dependency as well. But that will be in a separate commit.