### PR TITLE
Brought consistency to kubectl plugin naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,29 @@ KubePlus simplifies building and tracking workflow automation involving Kubernet
 
 KubePlus offers following kubectl commands:
 
-**1. kubectl man <Custom Resource>:** Provides information about how to use a Custom Resource.
+**1. kubectl man cr:** Provides information about how to use a Custom Resource.
 
-**2. kubectl composition <Custom Resource Instance>:** Provides information about sub resources created as part of handling a Custom Resource instance.
+**2. kubectl composition cr:** Provides information about sub resources created as part of handling a Custom Resource instance.
 
-**3. kubectl connections <Custom Resource Instance>: (upcoming)** Provides information about relationships of a Custom Resource instance with other resources (custom or built-in) via labels / annotations / spec properties / sub-resources.
+**3. kubectl connections:**
 
-**4. kubectl metrics cr <Custom Resource Instance>:** Provides various metrics for Custom Resource instance (number of sub-resources, number of pods, number of containers, number of nodes on which the pods run, total CPU and Memory).
+- ``kubectl connections cr``(upcoming): Provides information about relationships of a Custom Resource instance with other resources (custom or built-in) via labels / annotations / spec properties / sub-resources.
 
-**5. kubectl metrics account <Account Name>:** Provides various metrics for an account identity - user / service account. (number of custom resources, number of Deployments/StatefulSets/ReplicaSets/DaemonSets/ReplicationControllers, number of Pods, total CPU and Memory).
+- ``kubectl connections workflow``: Provides information about relationships between a Service object and all the downstream Pods related to it representing a workflow.
 
-**6. kubectl crlogs <Custom Resource Instance>:** Provides logs for all the containers of a Custom Resource instance.
+**4. kubectl metrics:** 
 
-**7. kubectl workflow logs <Service name>:** Provides logs for all the containers of all the Pods that are part of the workflow defined by the provided Service instance.
+- ``kubectl metrics cr``: Provides various metrics for Custom Resource instance (number of sub-resources, number of pods, number of containers, number of nodes on which the pods run, total CPU and Memory).
+
+- ``kubectl metrics account``: Provides various metrics for an account identity - user / service account. (number of custom resources, number of Deployments/StatefulSets/ReplicaSets/DaemonSets/ReplicationControllers, number of Pods, total CPU and Memory).
+
+- ``kubectl metrics workflow`` (upcoming): Provides CPU/Memory metrics for all the Pods that are part of a Workflow (direct and indirect descendants).
+
+**5. kubectl grouplogs:** 
+
+- ``kubectl grouplogs cr``:Provides logs for all the containers of a Custom Resource instance.
+
+- ``kubectl grouplogs workflow``: Provides logs for all the containers of all the Pods that are part of the workflow defined by the provided Service instance.
 
 
 ## Example

--- a/kubectl-connections-cr
+++ b/kubectl-connections-cr
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if (( $# < 1 )); then
+    echo "Coming soon.."
+    echo "kubectl connections cr <Custom Resource Kind> <Custom Resource Instance> [<Namespace>]"
+    exit 0
+fi

--- a/kubectl-connections-workflow
+++ b/kubectl-connections-workflow
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if (( $# < 1 )); then
+    echo "kubectl connections workflow Service <Service Instance name> [<Namespace>]"
+    exit 0
+fi
+
+serviceInstance=$2
+namespace="default"
+if [ $# = 3 ]; then
+   namespace=$3 # If namespace is passed; use that
+fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	./discovery-manager/kubediscovery-macos connections Service $serviceInstance $namespace
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+	./discovery-manager/kubediscovery-linux connections Service $serviceInstance $namespace 
+	echo "$OSTYPE not supported."
+fi

--- a/kubectl-grouplogs-cr
+++ b/kubectl-grouplogs-cr
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if (( $# < 2 )); then
-    echo "kubectl crlogs <Custom Resource> <Resource Instance> [<Namespace>]"
+    echo "kubectl grouplogs cr <Custom Resource> <Resource Instance> [<Namespace>]"
     exit 0
 fi
 

--- a/kubectl-grouplogs-workflow
+++ b/kubectl-grouplogs-workflow
@@ -16,7 +16,7 @@ function podLogs {
 }
 
 if (( $# < 1 )); then
-    echo "kubectl workflow logs Service <Service Instance name> [<Namespace>]"
+    echo "kubectl grouplogs workflow Service <Service Instance name> [<Namespace>]"
     exit 0
 fi
 

--- a/kubectl-metrics-workflow
+++ b/kubectl-metrics-workflow
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if (( $# < 1 )); then
+    echo "Coming soon.."
+    echo "kubectl metrics workflow Service <Service Instance name> [<Namespace>]"
+    exit 0
+fi
+


### PR DESCRIPTION
Format: kubectl <verb> <noun>

kubectl composition cr
kubectl composition workflow
kubectl metrics cr
kubectl metrics workflow
kubectl grouplogs cr
kubectl grouplogs workflow