### PR TITLE
Migrating examples to Helm(v3)

### DIFF
--- a/deploy/deploy-kubeplus.sh
+++ b/deploy/deploy-kubeplus.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Create Tiller service account
-kubectl create -f helm-rbac-config.yaml
+#kubectl create -f helm-rbac-config.yaml
 
 # Start Tiller
-helm init --service-account tiller
+#helm init --service-account tiller
 
 # Deploy KubePlus API Server - Planning to remove KubePlus API Server
 # kubectl apply -f ../deploy/

--- a/examples/elastic/steps.txt
+++ b/examples/elastic/steps.txt
@@ -10,7 +10,7 @@ various Custom Resource managed by the Operator.
 
 Setup:
 -------
-- Download Minikube (v0.34.0), download Helm (v2.11.0)
+- Download Minikube (v0.34.0), download Helm (v3)
 
 
 Steps:
@@ -19,49 +19,29 @@ Steps:
 1) Create Kubernetes Cluster
    - minikube start --memory 4096
 
-2) Install KubePlus
-   - git clone https://github.com/cloud-ark/kubeplus.git
-   - cd kubeplus
-   - kubectl apply -f deploy
+2) Install KubePlus kubectl plugins
+   - check README.md at https://github.com/cloud-ark/kubeplus.git
 
-3) Setup Helm
-   - kubectl create -f scripts/helm-rbac-config.yaml
-   - helm init --service-account tiller
+3) Deploy Elastic Operator
+   - helm install https://github.com/cloud-ark/operatorcharts/blob/master/elastic-operator-chart-0.8.2.tgz?raw=true
 
-4) Wait till Tiller Pod is running
-   - kubectl get pods -n kube-system
-
-5) Once Tiller Pod is ready, deploy Elastic Operator
-   - helm install https://github.com/cloud-ark/operatorcharts/blob/master/elastic-operator-chart-0.8.1.tgz?raw=true
-
-6) Wait till the Operator Pod is ready
+4) Wait till the Operator Pod is ready
    - kubectl get ns
    - kubectl get pods -n elastic-ns
 
-7) Find available Custom Resources
-   - kubectl get customresourcedefinitions
-
-8) Find the Custom Resource Kind name for Elasticsearch CRD
-   - kubectl describe customresourcedefinitions elasticsearches.elasticsearch.k8s.elastic.co
-
-9) Check static information such as how-to use guide for the Elasticsearch Kind
+5) Check static information such as how-to use guide for the Elasticsearch Kind
    - kubectl man Elasticsearch
 
-10) Deploy Elasticsearch instance
+6) Deploy Elasticsearch instance
     - kubectl create -f es.yaml
 
-11) Check dynamic information such as the native Kubernetes resources that are created by the Operator
+7) Check dynamic information such as the native Kubernetes resources that are created by the Operator
     for managing Elasticsearch custom resource instance
     - kubectl connections Elasticsearch quickstart
-
 
 
 Troubleshooting
 ----------------
 
-1) Get KubePlus logs
-   - kubectl get pods
-   - kubectl logs <kubeplus-pod-name> -c kube-discovery-apiserver
-
-2) Check Helm Deployments
+1) Check Helm Deployments
    - helm list

--- a/examples/moodle-with-ssl/steps.txt
+++ b/examples/moodle-with-ssl/steps.txt
@@ -18,6 +18,7 @@ Setup:
 - Configure your kubectl to connect to the GKE cluster
   - gcloud container clusters get-credentials <cluster-name> --zone <zone-name>
 - Register two Domain names on AWS Route53
+- Use Helm v2 for this example.
 
 Steps:
 ------

--- a/examples/moodle/steps.txt
+++ b/examples/moodle/steps.txt
@@ -13,7 +13,7 @@ an example of how to specify installation of additional plugins on an existing M
 
 Setup:
 -------
-- Download Minikube (v0.30.0), download Helm (v2.11.0)
+- Download Minikube (v0.30.0), download Helm (v3)
 
 Steps:
 -------
@@ -26,38 +26,25 @@ Steps:
 
 2) git clone https://github.com/cloud-ark/kubeplus.git
 
-3) cd kubeplus
+3) cd kubeplus/deploy
 
-4) Setup Helm Service Account
-   - kubectl create -f helm.yaml
+4) ./deploy-kubeplus.sh
 
-5) Setup Helm
-   - helm init --service-account helm
-
-6) Wait till Tiller Pod is running
-   - kubectl get pods -n kube-system
-
-7) Once Helm Pod is ready, deploy Kubeplus
-   - kubectl apply -f deploy/
-
-8) Wait till kubeplus is ready (4/4 Ready containers)
+5) Wait till kubeplus is ready (5/5 Ready containers)
    - kubectl get pods
 
-9) cd examples/moodle
+6) cd examples/moodle
 
-10) Deploy Moodle Operator
+7) Deploy Moodle Operator
    - kubectl create -f moodle-operator.yaml
 
-11) Wait till Moodle Operator pod is ready
+8) Wait till Moodle Operator pod is ready
    - kubectl get pods
 
-12) Find information about Moodle Custom Kind registered by Moodle Operator
-    - kubectl get operators
-    - kubectl describe operators moodle-operator
-    - kubectl describe customresourcedefinition moodles.moodlecontroller.kubeplus
+9) Find information about Moodle Custom Kind registered by Moodle Operator
     - kubectl man Moodle
 
-13) Deploy Moodle1 instance
+10) Deploy Moodle1 instance
     - First deploy MySQL as database for the Moodle instance
       - kubectl create -f moodle1-mysql.yaml
       - kubectl get pods (Wait will mysql pod is ready)
@@ -90,7 +77,7 @@ Steps:
     - Find connections tree of Moodle1 instance
       - kubectl connections Moodle moodle1 default -o json | python -m json.tool
 
-14) Update Moodle Deployment to install new Plugin
+11) Update Moodle Deployment to install new Plugin
     - We will install 'wiris' plugin on 'moodle1' Moodle instance
     - kubectl apply -f update-moodle1.yaml
 
@@ -103,7 +90,7 @@ Steps:
       - Navigate to -> Administration -> Plugins -> Plugins Overview
       - You should see 'profilecohort' and 'wiris' plugins in the 'Additional plugins' list
 
-15) Deploy Moodle2 instance
+12) Deploy Moodle2 instance
     - kubectl create -f moodle2-mysql.yaml
     - kubectl get pods (Wait will MySQL Pod is ready)
     - kubectl create -f moodle2.yaml
@@ -121,7 +108,7 @@ Steps:
           - Login using 'admin' as username and retrieve password from moodle2 secret as described 
             in step 12.
 
-16) Cleanup
+13) Cleanup
     - kubectl delete -f moodle1.yaml
     - kubectl delete -f moodle1-mysql.yaml
     - kubectl delete -f moodle2.yaml
@@ -132,10 +119,5 @@ Steps:
 Troubleshooting
 ----------------
 
-1) Get KubePlus logs
-   - kubectl get pod <kubeplus-pod> -c operator-manager
-   - kubectl get pod <kubeplus-pod> -c operator-deployer
-   - kubectl get pod <kubeplus-pod> -c kube-discovery-apiserver
-
-2) Check Helm Deployments
+1) Check Helm Deployments
    - helm list

--- a/examples/wordpress-mysqlcluster/steps.txt
+++ b/examples/wordpress-mysqlcluster/steps.txt
@@ -11,30 +11,17 @@ Steps:
   - GKE
      - Create a GKE cluster with 4vCPUs and 15.00 GB memory minimum
 
-2) Setup Helm
-   - kubectl create -f scripts/helm-rbac-config.yaml
-   - helm init --service-account tiller
-
-3) Wait till Tiller Pod is running
-   - kubectl get pods -n kube-system
-
-4) Once Helm Pod is ready, deploy MySQL Operator and apply Cert-Manager CRDs
-   - helm install https://github.com/cloud-ark/operatorcharts/blob/master/mysql-operator-0.2.5-4.tgz?raw=true
+2) Once Helm Pod is ready, deploy MySQL Operator and apply Cert-Manager CRDs
+   - helm install https://github.com/cloud-ark/operatorcharts/blob/master/mysql-operator-0.2.5-6.tgz?raw=true
    - kubectl create -f cert-manager-crds-release0.8.yaml
 
-5) Wait till MysqlCluster Operator Pod is ready
+3) Wait till MysqlCluster Operator Pod is ready
    - kubectl get pods
-
-6) Find available Custom Resources
-   - kubectl get customresourcedefinitions
-
-7) Find the Custom Resource Kind names
-   - kubectl describe customresourcedefinitions mysqlclusters.mysql.presslabs.org
   
-8) Find more information like how-to use, Spec properties, etc. for each Kind
+4) Find more information like how-to use, Spec properties, etc. for each Kind
    - kubectl man MysqlCluster
 
-9) Deploy Wordpress in namespace1
+5) Deploy Wordpress in namespace1
    - kubectl create ns namespace1
    
    - Create MysqlCluster Custom Resource instance
@@ -57,12 +44,12 @@ Steps:
      - kubectl create -f wordpress-ingress.yaml
      - kubectl create -f clusterissuer.yaml
 
-10) Check the connections
+6) Check the connections
     - kubectl connections MysqlCluster cluster1 namespace1
     - kubectl connections Service wordpress namespace1
     - kubectl connections <Pod-name> namespace1
 
-11) Cleanup
+7) Cleanup
      - kubectl delete -f wordpress-pod.yaml
      - kubectl delete -f wordpress-service.yaml
      - kubectl delete -f wordpress-ingress.yaml


### PR DESCRIPTION
- Except for two examples (postgres and moodle-with-ssl),
rest are now migrated to use Helm v3 charts