### PR TITLE
Fixing incorrect image name in team multi-tenancy example

### DIFF
--- a/examples/multitenancy/team/ns1pod.yaml
+++ b/examples/multitenancy/team/ns1pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx1233444
+    image: nginx
     ports:
     - containerPort: 80
     volumeMounts:


### PR DESCRIPTION
Fixes: https://github.com/cloud-ark/kubeplus/issues/707