### PR TITLE
Creating service instances in separate namespaces

### DIFF
--- a/consumerui/consumerui.py
+++ b/consumerui/consumerui.py
@@ -69,7 +69,8 @@ def get_total_resources(service):
 
 	for instance in instance_list:
 		res = instance['name']
-		namespace = instance['namespace']
+		namespace = res # Each instance of CRD is installed in its own Namespace
+		#namespace = instance['namespace']
 
 		cpu, memory, storage, nwTransmitBytes, nwReceiveBytes = get_metrics(service, res, namespace)
 
@@ -95,6 +96,7 @@ def get_input_fields(serviceName):
 	version = ""
 	apiVersion = ""
 	fieldList = []
+        # invariant we want to maintain - fieldList should not contain namespace
 	if out != "":
 		lines = out.split("\n")
 		specFields = False
@@ -155,9 +157,11 @@ def get_field_names(service):
 	print(service)
 	kind, apiVersion, fields = get_input_fields(service)
 
-	# the name of the resource and namespace needs to be input as well.
-	if 'namespace' not in fields:
-		fields.insert(0,"namespace")
+	# the name of the resource needs to be input as well.
+        # We are not requiring namespace to be input since the consumer
+        # does not really know what value should be provided to the namespace value.
+	#if 'namespace' not in fields:
+	#	fields.insert(0,"namespace")
 	if 'name' not in fields:
 		fields.insert(0,"name") 
 	fields_dict = {}
@@ -208,8 +212,8 @@ def create_instance():
 	namespace = "default"
 	metadata["name"] = resName
 	res["metadata"] = metadata
-	if 'namespace' in fieldMap:
-		namespace = fieldMap["namespace"]
+	#if 'namespace' in fieldMap:
+	#	namespace = fieldMap["namespace"]
 	metadata["namespace"] = namespace
 	spec = {}
 	for k,v in fieldMap.items():


### PR DESCRIPTION
B2B SaaS on K8s is achieved by deploying separate instance
of the application for each customer. To achieve strict
isolation and multi-tenancy, such instances are deployed in
separate namespaces. This is called as the multi-instance
multi-tenancy of the K8S based SaaS model [1].

This patch adds the support to enable this SaaS model in KubePlus.
KubePlus will now create a new namespace for deploying the
Helm release corresponding to a service instance.
The name of the namespace is taken to be same as the name
of the service instance. KubePlus first creates the NS and then passes
that to the Helm install command. All the resources that
are part of the Helm release are created in this NS.
Note that following restrictions are required on the Helm chart
underlying the service.
- The Helm chart should not contain Namespace definition. This
is because all the Helm chart resources are going to be created in the new
NS that KubePlus creates for that instance. Since Kubernetes Namespaces cannot be nested
the Namespace defined in the Helm chart will get created just as an object
in the NS that KubePlus creates. But it won't contain any of the actual service instance
resources. They will be present in the NS that KubePlus has created.
- The Helm chart should not take Namespace field as input through
values.yaml. This is because the Namespace name so entered will
be overridden by the NS that KubePlus creates.
We are tracking above two points in below issues:

https://github.com/cloud-ark/kubeplus/issues/910
https://github.com/cloud-ark/kubeplus/issues/911

[1] https://cloudark.medium.com/multi-instance-multi-tenancy-in-kubernetes-273cd22ae019