### PR TITLE
Plugins updates

### DIFF
--- a/plugins/kubectl-man
+++ b/plugins/kubectl-man
@@ -12,11 +12,7 @@ fi
 
 kind=$1
 
-kubeconfig1="$HOME/.kube/config" #default value
-
-kubeconfig="--kubeconfig="$kubeconfig1
-
-check_kind $kind $kubeconfig
+check_kind $kind
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	/$KUBEPLUS_HOME/plugins/kubediscovery-macos man $kind

--- a/plugins/kubectl-metrics
+++ b/plugins/kubectl-metrics
@@ -65,7 +65,7 @@ done
 kubeconfig="--kubeconfig="$kubeconfig1
 check_namespace $namespace $kubeconfig
 
-check_kind $customres $kubeconfig
+check_kind $customres
 
 #if [ $# == 5 ]; then
 #    output=$5

--- a/plugins/utils.sh
+++ b/plugins/utils.sh
@@ -15,9 +15,8 @@ check_namespace() {
 
 check_kind() {
   local kind=$1
-  local kubeconfig=$2
 
-  canonicalKindPresent=`kubectl api-resources $kubeconfig | grep -w $kind`
+  canonicalKindPresent=`kubectl api-resources | grep -w $kind`
   OLDIFS=$IFS
   IFS=' '
   read -a canonicalKindPresentArr <<< "$canonicalKindPresent"


### PR DESCRIPTION
man and metrics updated to not use kubeconfig flag
when checking for the existence of the input Kind.
The reason is - the default kubeconfig location does
not work from insider the helmer container when retrieving metrics.