### PR TITLE
Added test to check application Helm chart against Kyverno policies

### DIFF
--- a/tests/block-stale-images.yaml
+++ b/tests/block-stale-images.yaml
@@ -1,0 +1,40 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: block-stale-images
+  annotations:
+    policies.kyverno.io/title: Block Stale Images
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Images that are old usually have some open security vulnerabilities which are not patched.
+      This policy checks the contents of every container image and inspects them for the create time.
+      If it finds any image which was built more than 6 months ago this policy blocks the deployment.      
+spec:
+  validationFailureAction: enforce
+  rules:
+    - name: block-stale-images
+      match:
+        any:
+        - resources:
+            kinds:
+            - Pod
+      validate:
+        message: "Images built more than 6 months ago are prohibited."
+        foreach:
+        - list: "request.object.spec.containers"
+          context:
+          - name: imageData
+            imageRegistry:
+              reference: "{{ element.image }}"
+          deny:
+            conditions:
+              all:
+                - key: "{{ time_since('', '{{ imageData.configData.created }}', '') }}"
+                  operator: GreaterThan
+                  value: 4380h
+


### PR DESCRIPTION
Assumes that Kyverno is installed on the cluster.
Before wrapping application Helm chart with a CRD, KubePlus will create a test release of the chart to trigger policy checks from Kyverno. If the checks fail then KubePlus will not create the CRD.