### PR TITLE
Fixes discrepancies in `steps.txt` files.

### DIFF
--- a/examples/multitenancy/odoo/steps.txt
+++ b/examples/multitenancy/odoo/steps.txt
@@ -4,99 +4,97 @@ This example shows delivering Bitnami Odoo Helm chart as-a-service using KubePlu
 
 
 1. Download Odoo helm chart from Bitnami:
-   - helm repo add bitnami https://charts.bitnami.com/bitnami
-   - helm pull bitnami/odoo
+   $ helm repo add bitnami https://charts.bitnami.com/bitnami
+   $ helm pull bitnami/odoo
 
-2. Install KubePlus and setup KubePlus kubectl plugins
+2. Install KubePlus and setup KubePlus kubectl plugins:
    - Create provider kubeconfig:
      - Minikube:
-       - python ../../../provider-kubeconfig.py create default
+       $ python ../../../provider-kubeconfig.py create default
      - GKE:
-       - export PROJECT_ID=<your-gcp-project>
-       - export CLOUDSDK_COMPUTE_ZONE=<gcp-zone-of-your-cluster>
-       - export KUBECONFIG=<location-to-store-admin-kubeconfig-file>
-       - gcloud container clusters get-credentials <cluster-name>
-       - server=`more $KUBECONFIG | grep server | cut -d '/' -f 3`
-       - python ../../../provider-kubeconfig.py create default -s $server
+       $ export PROJECT_ID=<your-gcp-project>
+       $ export CLOUDSDK_COMPUTE_ZONE=<gcp-zone-of-your-cluster>
+       $ export KUBECONFIG=<location-to-store-admin-kubeconfig-file>
+       $ gcloud container clusters get-credentials <cluster-name>
+       $ server=`more $KUBECONFIG | grep server | cut -d '/' -f 3`
+       $ python ../../../provider-kubeconfig.py create default -s $server
    - Install KubePlus
-     - helm install kubeplus "https://github.com/cloud-ark/operatorcharts/blob/master/kubeplus-chart-3.0.29.tgz?raw=true" --kubeconfig=kubeplus-saas-provider.json 
-     - Wait till KubePlus Pod is Running (kubectl get pods -A)
+     $ helm install kubeplus "https://github.com/cloud-ark/operatorcharts/blob/master/kubeplus-chart-3.0.28.tgz?raw=true" --kubeconfig=kubeplus-saas-provider.json 
+   - Wait till KubePlus Pod is Running
+     $ kubectl get pods -A
 
    - Setup KubePlus kubectl plugins
-     wget https://github.com/cloud-ark/kubeplus/blob/master/kubeplus-kubectl-plugins.tar.gz
-     gunzip kubeplus-kubectl-plugins.tar.gz
-     tar -xvf kubeplus-kubectl-plugins
-     export KUBEPLUS_HOME=`pwd`
-     export PATH=$KUBEPLUS_HOME/plugins:$PATH
+     $ wget https://github.com/cloud-ark/kubeplus/blob/master/kubeplus-kubectl-plugins.tar.gz
+     $ gunzip kubeplus-kubectl-plugins.tar.gz
+     $ tar -xvf kubeplus-kubectl-plugins
+     $ export KUBEPLUS_HOME=`pwd`
+     $ export PATH=$KUBEPLUS_HOME/plugins:$PATH
 
-3. Create OdooService API wrapping the Helm chart
+3. Create OdooService API wrapping the Helm chart:
    - Check odoo-service-composition-localchart.yaml. Notice that we are specifying the odoo chart from a file system based path.
      So first we have to upload this chart to KubePlus Pod.
-   - kubectl upload chart odoo-23.0.4.tgz 
-   - kubectl create -f odoo-service-composition-localchart.yaml --kubeconfig=kubeplus-saas-provider.json 
-   - kubectl get crds --kubeconfig=kubeplus-saas-provider.json
+   $ kubectl upload chart odoo-23.0.4.tgz 
+   $ kubectl create -f odoo-service-composition-localchart.yaml --kubeconfig=kubeplus-saas-provider.json 
+   $ kubectl get crds --kubeconfig=kubeplus-saas-provider.json
      - verify that odooservice crd has been created
-   - kubectl describe crd odooservices.platformapi.kubeplus --kubeconfig=kubeplus-saas-provider.json
+   $ kubectl describe crd odooservices.platformapi.kubeplus --kubeconfig=kubeplus-saas-provider.json
      - check that OpenAPISchema has been defined on the CRD corresponding to the attributes in the values.yaml of the Odoo Helm chart. 
 
-4. Download the consumer kubeconfig file
+4. Download the consumer kubeconfig file:
    - Direct
-     - kubectl get configmaps kubeplus-saas-consumer-kubeconfig -n $KUBEPLUS_NS -o jsonpath="{.data.kubeplus-saas-consumer\.json}" > consumer.conf
+     $ kubectl get configmaps kubeplus-saas-consumer-kubeconfig -n $KUBEPLUS_NS -o jsonpath="{.data.kubeplus-saas-consumer\.json}" > consumer.conf
    - Using kubeplus plugin (use when working on GKE)
-     - kubectl retrieve kubeconfig consumer default -s https://$server:443 -k kubeplus-saas-provider.json > consumer.conf
+     $ kubectl retrieve kubeconfig consumer default -s https://$server:443 -k kubeplus-saas-provider.json > consumer.conf
 
 5. Check permissions for provider and consumer service accounts, which are created by KubePlus:
-   - kubectl auth can-i --list --as=system:serviceaccount:default:kubeplus-saas-provider
-   - kubectl auth can-i --list --as=system:serviceaccount:default:kubeplus-saas-consumer
+   $ kubectl auth can-i --list --as=system:serviceaccount:default:kubeplus-saas-provider
+   $ kubectl auth can-i --list --as=system:serviceaccount:default:kubeplus-saas-consumer
  
    In the below steps you can use either consumer.conf or kubeplus-saas-provider.json
 
-6. Check details of OdooService API
-   - kubectl explain OdooService --kubeconfig=kubeplus-saas-provider.json
-   - kubectl explain OdooService.spec --kubeconfig=kubeplus-saas-provider.json
+6. Check details of OdooService API:
+   $ kubectl explain OdooService --kubeconfig=kubeplus-saas-provider.json
+   $ kubectl explain OdooService.spec --kubeconfig=kubeplus-saas-provider.json
 
-7. Retrieve sample OdooService resource
-   - kubectl man OdooService -k kubeplus-saas-provider.json
+7. Retrieve sample OdooService resource:
+   $ kubectl man OdooService -k kubeplus-saas-provider.json
      - this will show a sample odooservice object in which the spec properties are 
        attributes in the Odoo Helm chart's values.yaml file
-   - kubectl man OdooService -k kubeplus-saas-provider.json > sample-odooservice.yaml
+   $ kubectl man OdooService -k kubeplus-saas-provider.json > sample-odooservice.yaml
 
-8. Create Odoo instance
+8. Create Odoo instance:
    - Open sample-odooservice.yaml and make following changes
      - set OdooService.spec.service.type to "NodePort"
      - set OdooService.spec.service.nodePorts.http to "30001"
-   - kubectl create -f sample-odooservice.yaml --kubeconfig=kubeplus-saas-provider.json
+   $ kubectl create -f sample-odooservice.yaml --kubeconfig=kubeplus-saas-provider.json
      - verify that the application Pods are created in a new namespace (kubectl get pods -A)
 
-9. Check the created resources
-   - kubectl appresources OdooService sample-odooservice -k kubeplus-saas-provider.json
+9. Check the created resources:
+   $ kubectl appresources OdooService sample-odooservice -k kubeplus-saas-provider.json
      - this will show all the resources that KubePlus has created for the odoo instance
 
-10. Check logs
-   - kubectl applogs OdooService sample-odooservice default -k kubeplus-saas-provider.json 
+10. Check logs:
+    $ kubectl applogs OdooService sample-odooservice default -k kubeplus-saas-provider.json 
 
-11. Get application URL
-    - appurl=`kubectl appurl OdooService sample-odooservice default -k kubeplus-saas-provider.json`
-    - curl $appurl/web/login
+11. Get application URL:
+    $ appurl=`kubectl appurl OdooService sample-odooservice default -k kubeplus-saas-provider.json`
+    $ curl $appurl/web/login
       - if the installation is successful, the curl call should return 200 OK.
 
-12. Login to Odoo instance
-    - kubectl describe odooservices sample-odooservice --kubeconfig=kubeplus-saas-provider.json
+12. Login to Odoo instance:
+    $ kubectl describe odooservices sample-odooservice --kubeconfig=kubeplus-saas-provider.json
     - Get the ODOO_EMAIL and ODOO_PASSWORD by running the commands from the above output
     - Navigate to $appurl/web/login in the browser and login using ODOO_EMAIL and ODOO_PASSWORD
 
-13. Check metrics
-    - kubectl metrics OdooService sample-odooservice default -k kubeplus-saas-provider.json 
-    - kubectl metrics OdooService sample-odooservice default -k kubeplus-saas-provider.json -o prometheus
+13. Check metrics:
+    $ kubectl metrics OdooService sample-odooservice default -k kubeplus-saas-provider.json 
+    $ kubectl metrics OdooService sample-odooservice default -k kubeplus-saas-provider.json -o prometheus
 
-14. Check resource topology
-    - kubectl connections OdooService sample-odooservice default -k kubeplus-saas-provider.json
-    - kubectl connections OdooService sample-odooservice default -k kubeplus-saas-provider.json -o png
-
+14. Check resource topology:
+    $ kubectl connections OdooService sample-odooservice default -k kubeplus-saas-provider.json
+    $ kubectl connections OdooService sample-odooservice default -k kubeplus-saas-provider.json -o png
 
 Clean up:
-- kubectl delete -f sample-odooservice.yaml --kubeconfig=kubeplus-saas-provider.json
-- kubectl delete -f odoo-service-composition-localchart.yaml --kubeconfig=kubeplus-saas-provider.json
-
-
+$ kubectl delete -f sample-odooservice.yaml --kubeconfig=kubeplus-saas-provider.json
+$ kubectl delete -f odoo-service-composition-localchart.yaml --kubeconfig=kubeplus-saas-provider.json
 

--- a/examples/multitenancy/odoo/steps.txt
+++ b/examples/multitenancy/odoo/steps.txt
@@ -19,7 +19,7 @@ This example shows delivering Bitnami Odoo Helm chart as-a-service using KubePlu
        $ server=`more $KUBECONFIG | grep server | cut -d '/' -f 3`
        $ python ../../../provider-kubeconfig.py create default -s $server
    - Install KubePlus
-     $ helm install kubeplus "https://github.com/cloud-ark/operatorcharts/blob/master/kubeplus-chart-3.0.28.tgz?raw=true" --kubeconfig=kubeplus-saas-provider.json 
+     $ helm install kubeplus "https://github.com/cloud-ark/operatorcharts/blob/master/kubeplus-chart-3.0.29.tgz?raw=true" --kubeconfig=kubeplus-saas-provider.json 
    - Wait till KubePlus Pod is Running
      $ kubectl get pods -A
 

--- a/examples/multitenancy/wordpress/steps.txt
+++ b/examples/multitenancy/wordpress/steps.txt
@@ -1,88 +1,82 @@
-Setup:
-------
-Install Helm v3
-Install minikube
-
-Create minikube cluster
-- minikube start --kubernetes-version=v1.24.3
-
-Install KubePlus kubectl plugins
-$ wget https://github.com/cloud-ark/kubeplus/raw/master/kubeplus-kubectl-plugins.tar.gz
-$ gunzip kubeplus-kubectl-plugins.tar.gz
-$ tar -xvf kubeplus-kubectl-plugins.tar
-$ export KUBEPLUS_HOME=`pwd`
-$ export PATH=$KUBEPLUS_HOME/plugins/:$PATH
-$ kubectl kubeplus commands
-
-Get Provider and consumer kubeconfigs:
----------------------------------------
-Extract provider kubeconfig:
-- KUBEPLUS_NS=default
-- python ../../../provider-kubeconfig.py create $KUBEPLUS_NS
-
-Install KubePlus Operator 
-$ helm install kubeplus "https://github.com/cloud-ark/operatorcharts/blob/master/kubeplus-chart-3.0.29.tgz?raw=true" -n $KUBEPLUS_NS --kubeconfig=kubeplus-saas-provider.json
+Wordpress as-a-Service
+-------------------
+This example shows delivering Wordpress Helm chart as-a-service using KubePlus.
 
 
-Extract consumer kubeconfig:
-- kubectl get configmaps kubeplus-saas-consumer-kubeconfig -n $KUBEPLUS_NS -o jsonpath="{.data.kubeplus-saas-consumer\.json}" > consumer.conf
+1. Setup:
+   - Install Helm v3
+   - Install minikube
+   - Create minikube cluster
+     $ minikube start --kubernetes-version=v1.24.3
 
+2. Install KubePlus kubectl plugins:
+   $ wget https://github.com/cloud-ark/kubeplus/raw/master/kubeplus-kubectl-plugins.tar.gz
+   $ gunzip kubeplus-kubectl-plugins.tar.gz
+   $ tar -xvf kubeplus-kubectl-plugins.tar
+   $ export KUBEPLUS_HOME=`pwd`
+   $ export PATH=$KUBEPLUS_HOME/plugins/:$PATH
+   $ kubectl kubeplus commands
 
-Create new consumer API:
-------------------------
-Create WordpressService consumer API registering the Wordpress Helm chart with it.
-- Check wordpress-service-composition.yaml
-  - If required modify the Pod policies in the podconfig section (cpu/memory requests and limits) 
-  - kubectl create -f wordpress-service-composition.yaml --kubeconfig=kubeplus-saas-provider.json
-- Verify WordpressStack CRD registered
-  - until kubectl get crds --kubeconfig=kubeplus-saas-provider.json | grep wordpressservices.platformapi.kubeplus  ; do echo "Waiting for WordpressService CRD to be registered.."; sleep 1; done
+3. Get Provider and consumer kubeconfigs:
+   - Extract provider kubeconfig:
+     $ KUBEPLUS_NS=default
+     $ python ../../../provider-kubeconfig.py create $KUBEPLUS_NS
 
+4. Install KubePlus Operator:
+   $ helm install kubeplus "https://github.com/cloud-ark/operatorcharts/blob/master/kubeplus-chart-3.0.28.tgz?raw=true" -n $KUBEPLUS_NS --kubeconfig=kubeplus-saas-provider.json
 
-Create Tenant1 Wordpress stack: 
------------------------------------
-You can use either the kubeplus-saas-provider.json or consumer.conf in below commands.
+5. Extract consumer kubeconfig:
+   $ kubectl get configmaps kubeplus-saas-consumer-kubeconfig -n $KUBEPLUS_NS -o jsonpath="{.data.kubeplus-saas-consumer\.json}" > consumer.conf
 
-Check the man page for WordpressService to learn about what spec properties are available on the WordpressService resource
-- kubectl man WordpressService -k kubeplus-saas-provider.json
+6. Create new consumer API:
+   - Create WordpressService consumer API registering the Wordpress Helm chart with it.
+     - Check wordpress-service-composition.yaml
+     - If required modify the Pod policies in the podconfig section (cpu/memory requests and limits) 
+     $ kubectl create -f wordpress-service-composition.yaml --kubeconfig=kubeplus-saas-provider.json
+   - Verify WordpressStack CRD registered
+     $ until kubectl get crds --kubeconfig=kubeplus-saas-provider.json | grep wordpressservices.platformapi.kubeplus  ; do echo "Waiting for WordpressService CRD to be registered.."; sleep 1; done
 
-Deploy WordPressService for tenant1
-- kubectl create -f tenant1.yaml --kubeconfig=kubeplus-saas-provider.json
+7. Create tenant1 Wordpress stack: 
+   - You can use either the kubeplus-saas-provider.json or consumer.conf in below commands.
 
-Verify that WP instance is created:
-- kubectl get ns --kubeconfig=kubeplus-saas-provider.json
-  -> verify that wp-for-tenant1 namespace is created
-- kubectl describe wordpressservice wp-for-tenant1 --kubeconfig=kubeplus-saas-provider.json
-  -> should see the name of the helm release in the status field
-- kubectl get pods -n wp-for-tenant1 --kubeconfig=kubeplus-saas-provider.json
-  -> should see 2 pods getting created
+8. Check the man page for WordpressService to learn about what spec properties are available on the WordpressService resource:
+   $ kubectl man WordpressService -k kubeplus-saas-provider.json
 
-Wait till all the wp-for-tenant1 instance pods are in 'Running' state.
-Then perform following actions:
+9. Deploy WordPressService for tenant1:
+   $ kubectl create -f tenant1.yaml --kubeconfig=kubeplus-saas-provider.json
 
-Get Wordpress URL
-- kubectl appurl WordpressService wp-for-tenant1 $KUBEPLUS_NS -k kubeplus-saas-provider.json
-- curl -v <the app url output from above command>
-  - Note that this IP:Port combination will be reachable through your browser only
-    if you have opened up your Kubernetes cluster to traffic from outside world.
-- curl -v <value of the Location header from above response>
-  - should see the Wordpress install page details with options for various languages
+10. Verify that WP instance is created:
+    $ kubectl get ns --kubeconfig=kubeplus-saas-provider.json
+      -> verify that wp-tenant1 namespace is created
+    $ kubectl describe wordpressservice wp-tenant1 --kubeconfig=kubeplus-saas-provider.json
+      -> should see the name of the helm release in the status field
+    $ kubectl get pods -n wp-tenant1 --kubeconfig=kubeplus-saas-provider.json
+      -> should see 2 pods getting created
 
-Check created resources
-- kubectl appresources WordpressService wp-for-tenant1 –k kubeplus-saas-provider.json
-  - should see all the created Kubernetes objects for this application instance
+11. Wait till all the wp-tenant1 instance pods are in 'Running' state, then perform following actions:
+    - Get Wordpress URL
+      $ kubectl appurl WordpressService wp-tenant1 $KUBEPLUS_NS -k kubeplus-saas-provider.json
+      $ curl -v <the app url output from above command>
+        - Note that this IP:Port combination will be reachable through your browser only
+          if you have opened up your Kubernetes cluster to traffic from outside world.
+      $ curl -v <value of the Location header from above response>
+        - should see the Wordpress install page details with options for various languages
 
-Get logs
-- kubectl applogs WordpressService wp-for-tenant1 $KUBEPLUS_NS -k kubeplus-saas-provider.json
-  - should see logs for all the containers in both the Pods
+12. Check created resources:
+    $ kubectl appresources WordpressService wp-tenant1 –k kubeplus-saas-provider.json
+      - should see all the created Kubernetes objects for this application instance
 
-Get metrics
-- kubectl metrics WordpressService wp-for-tenant1 $KUBEPLUS_NS -k kubeplus-saas-provider.json
+13. Get logs:
+    $ kubectl applogs WordpressService wp-tenant1 $KUBEPLUS_NS -k kubeplus-saas-provider.json
+      - should see logs for all the containers in both the Pods
 
-Visualize topology
-- kubectl connections WordpressService wp-for-tenant1 $KUBEPLUS_NS -o png -k kubeplus-saas-provider.json
-  - Check the generated png file. For reference check wp-service-connections.png
+14. Get metrics:
+    $ kubectl metrics WordpressService wp-tenant1 $KUBEPLUS_NS -k kubeplus-saas-provider.json
 
-Cleanup
---------
-- kubectl delete -f tenant1.yaml --kubeconfig=kubeplus-saas-provider.json
-- kubectl delete -f wordpress-service-composition.yaml --kubeconfig=kubeplus-saas-provider.json
+15. Visualize topology:
+    $ kubectl connections WordpressService wp-tenant1 $KUBEPLUS_NS -o png -k kubeplus-saas-provider.json
+      - Check the generated png file. For reference check wp-service-connections.png
+
+Clean up:
+$ kubectl delete -f tenant1.yaml --kubeconfig=kubeplus-saas-provider.json
+$ kubectl delete -f wordpress-service-composition.yaml --kubeconfig=kubeplus-saas-provider.json

--- a/examples/multitenancy/wordpress/steps.txt
+++ b/examples/multitenancy/wordpress/steps.txt
@@ -23,7 +23,7 @@ This example shows delivering Wordpress Helm chart as-a-service using KubePlus.
      $ python ../../../provider-kubeconfig.py create $KUBEPLUS_NS
 
 4. Install KubePlus Operator:
-   $ helm install kubeplus "https://github.com/cloud-ark/operatorcharts/blob/master/kubeplus-chart-3.0.28.tgz?raw=true" -n $KUBEPLUS_NS --kubeconfig=kubeplus-saas-provider.json
+   $ helm install kubeplus "https://github.com/cloud-ark/operatorcharts/blob/master/kubeplus-chart-3.0.29.tgz?raw=true" -n $KUBEPLUS_NS --kubeconfig=kubeplus-saas-provider.json
 
 5. Extract consumer kubeconfig:
    $ kubectl get configmaps kubeplus-saas-consumer-kubeconfig -n $KUBEPLUS_NS -o jsonpath="{.data.kubeplus-saas-consumer\.json}" > consumer.conf


### PR DESCRIPTION
Also reformats them to be more consistent.
In the Wordpress example, some of the steps had the old namespace name `wp-for-tenant` instead of the newer `wp-tenant`.