### PR TITLE
Added plugins to show provider and consumer permissions. 

### DIFF
--- a/plugins/kubectl-kubeplus-commands
+++ b/plugins/kubectl-kubeplus-commands
@@ -10,11 +10,13 @@ print_help () {
     echo "        kubectl metrics"
     echo "        kubectl applogs"
     echo "        kubectl appurl"
-    echo "	  kubectl appresources"
+    echo "        kubectl appresources"
     echo "        kubectl retrieve kubeconfig provider"
     echo "        kubectl retrieve kubeconfig consumer"
     echo "        kubectl grantpermission consumer"
     echo "        kubectl upload chart"
+    echo "        kubectl show provider permissions"
+    echo "        kubectl show consumer permissions"
     echo ""
     echo "DESCRIPTION"
     echo "        KubePlus provides a suite of kubectl plugins to discover, monitor and troubleshoot Kubernetes applications."
@@ -42,6 +44,9 @@ print_help () {
     echo "        A consumer will be able to create service instances only after that."
     echo "        - kubectl upload chart"
     echo "        Upload Helm chart (tgz) to KubePlus Operator."
+    echo ""
+    echo "        - kubectl show provider permissions shows the permissions for kubeplus-saas-provider service account in the namespace where kubeplus is installed."
+    echo "        - kubectl show consumer permissions shows the permissions for kubeplus-saas-consumer service account in the namespace where kubeplus is installed."
     exit 0
 }
 

--- a/plugins/kubectl-show-consumer-permissions
+++ b/plugins/kubectl-show-consumer-permissions
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source utils.sh
+
+print_help () {
+    echo "NAME"
+    echo "        kubectl show consumer permissions"
+    echo ""
+    echo "SYNOPSIS"
+    echo "        kubectl show consumer permissions <Namespace>"
+    echo ""
+    echo "DESCRIPTION"
+    echo "        kubectl show consumer permissions shows the permissions for kubeplus-saas-consumer service account in the namespace where kubeplus is installed."
+    exit 0
+}
+
+if (( $# < 1 || $# >= 2)); then
+  print_help
+fi
+
+namespace="$1"
+
+check_namespace $namespace
+
+kubectl auth can-i --list --as=system:serviceaccount:$namespace:kubeplus-saas-consumer

--- a/plugins/kubectl-show-provider-permissions
+++ b/plugins/kubectl-show-provider-permissions
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source utils.sh
+
+print_help () {
+    echo "NAME"
+    echo "        kubectl show provider permissions"
+    echo ""
+    echo "SYNOPSIS"
+    echo "        kubectl show provider permissions <Namespace>"
+    echo ""
+    echo "DESCRIPTION"
+    echo "        kubectl show provider permissions shows the permissions for kubeplus-saas-provider service account in the namespace where kubeplus is installed."
+    exit 0
+}
+
+if (( $# < 1 || $# >= 2)); then
+  print_help
+fi
+
+namespace="$1"
+
+check_namespace $namespace
+
+kubectl auth can-i --list --as=system:serviceaccount:$namespace:kubeplus-saas-provider


### PR DESCRIPTION
…take namespace in which Kubeplus is installed as input. They retrieve the permissions associated with kubeplus-saas-provider and kubeplus-saas-consumer serveraccounts, which Kubeplus creates for the provider and consumer. Fixes: https://github.com/cloud-ark/kubeplus/issues/1188