### PR TITLE
Add OpenCost Support, Update README, and Refactor GitHub Actions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,116 +4,159 @@ on:
 env:
   ACTIONS_RUNNER_DEBUG: true
   KUBEPLUS_TEST_OUTPUT: yes
+  KUBEPLUS_CI: true
 jobs:
   job1:
     runs-on: ubuntu-20.04
     name: Deploy to minikube
     steps:
-    - uses: actions/checkout@v2
-    - name: Start minikube
-      uses: medyagh/setup-minikube@master
-    - name: Try the cluster !
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Create k8s Kind Cluster
+      uses: helm/kind-action@v1
+
+    - name: Verify Cluster
       run: kubectl get pods -A
-    - name: Deploy KubePlus and application to minikube 
+
+    - name: Display Glibc Version
+      run: ldd --version
+
+    - name: Install Helm, Python3 LXML and Golang
       run: |
-        export SHELL=/bin/bash
-        eval $(minikube -p minikube docker-env)
-        echo "Glibc version"
-        ldd --version
         sudo apt-get install python3-lxml
-        echo "Installing helm..."
+        echo "Installing Helm..."
         wget https://get.helm.sh/helm-v3.12.1-linux-amd64.tar.gz
         gunzip helm-v3.12.1-linux-amd64.tar.gz
         tar -xvf helm-v3.12.1-linux-amd64.tar
         sudo mv linux-amd64/helm /usr/local/bin/.
-        echo "Installing golang..."
-        rm -rf /usr/local/go 
+        echo "Installing Golang..."
+        rm -rf /usr/local/go
         wget https://go.dev/dl/go1.22.4.linux-amd64.tar.gz
         sudo tar -C /usr/local -xzf go1.22.4.linux-amd64.tar.gz
         export PATH=$PATH:/usr/local/go/bin
         go version
+
+    - name: Prepare KubePlus Environment
+      run: |
+        echo "Setting up KubePlus environment..."
         echo "Current directory:`pwd`"
-        echo "Folders:`ls`"
-        kubeplus_folder="$(basename `pwd`)"
-        echo "KubePlus folder name:$kubeplus_folder"
         mkdir -p $HOME/go/src/github.com/cloud-ark
         cd ..
-        runner_dir=`pwd`
         echo "Current directory:`pwd`"
-        mv $kubeplus_folder $HOME/go/src/github.com/cloud-ark/kubeplus
+        kubeplus_folder="$(basename `pwd`)"
+        echo "KubePlus folder name:$kubeplus_folder"
+        cp -R $kubeplus_folder $HOME/go/src/github.com/cloud-ark/kubeplus
         cd $HOME/go/src/github.com/cloud-ark/kubeplus
-        export KUBEPLUS_HOME=`pwd`
-        export PATH=$KUBEPLUS_HOME/plugins:$PATH
-        echo "PATH:$PATH"
-        echo "KUBEPLUS_HOME:$KUBEPLUS_HOME"
-        kubectl kubeplus commands
         export KUBEPLUS_NS=default
-        python3 -m venv venv
-        source venv/bin/activate
-        pip3 install -r requirements.txt
-        apiserver=`kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'`
-        echo "API_SERVER_URL:$apiserver"
-        python3 provider-kubeconfig.py -s $apiserver create $KUBEPLUS_NS
-        deactivate
+        echo "KUBEPLUS_NS=default" >> $GITHUB_ENV
+        export KUBEPLUS_HOME=`pwd`
+        echo "KUBEPLUS_HOME=$KUBEPLUS_HOME" >> $GITHUB_ENV
+        export PATH=$KUBEPLUS_HOME/plugins:$PATH
+        echo "PATH=$PATH" >> $GITHUB_ENV
 
-        echo "Building mutating-webhook..."
+    - name: Build Mutating Webhook
+      run: |
+        echo "KUBEPLUS_HOME:$KUBEPLUS_HOME"
         cd $KUBEPLUS_HOME/mutating-webhook
-        export GO111MODULE=on; go get github.com/googleapis/gnostic@v0.4.0
+        export GO111MODULE=on
+        go get github.com/googleapis/gnostic@v0.4.0
         ./build-artifact.sh latest
 
-        echo "Building helmer..."
+    - name: Build Helmer
+      run: |
         cd $KUBEPLUS_HOME/platform-operator/helm-pod/
         go mod vendor
         ./build-artifact.sh latest
 
-        echo "Building platform-operator..."
+    - name: Build Platform Operator
+      run: |
         cd $KUBEPLUS_HOME/platform-operator
         ./build-artifact.sh latest
 
-        echo "Building kubeconfiggenerator..."
+    - name: Build KubeConfig Generator
+      run: |
         cd $KUBEPLUS_HOME/deploy
         ./build-artifact-kubeconfiggenerator.sh latest
-        #echo "Building webhook_init_container..."
-        #./build-artifact.sh latest
-        #echo "Building resource cleaner..."
-        #./build-artifact-clean.sh latest
 
-        #cd $KUBEPLUS_HOME/consumerui
-        #echo "Building consumer ui..."
-        #./build-artifact.sh latest
-
+    - name: List Docker Images
+      run: |
         cd $KUBEPLUS_HOME
-        ls
         docker images
 
-        echo "Installing KubePlus..."
-        helm install kubeplus ./deploy/kubeplus-chart --kubeconfig=kubeplus-saas-provider.json --set MUTATING_WEBHOOK=gcr.io/cloudark-kubeplus/pac-mutating-admission-webhook:latest --set PLATFORM_OPERATOR=gcr.io/cloudark-kubeplus/platform-operator:latest --set HELMER=gcr.io/cloudark-kubeplus/helm-pod:latest --set CRD_REGISTRATION_HELPER=gcr.io/cloudark-kubeplus/kubeconfiggenerator:latest  -n $KUBEPLUS_NS
+    - name: Deploy KubePlus, Prometheus, and OpenCost to minikube
+      run: |
+        echo "Deploying KubePlus, Prometheus, and OpenCost..."
+        wget https://raw.githubusercontent.com/opencost/opencost/develop/configs/default.json
+        ./install.sh --prometheus --opencost default.json --kubeplus-plugin --kubeplus $KUBEPLUS_NS
 
-        kubectl get pods -A
+    - name: Verify Prometheus Installation
+      run: |
+        echo "Verifying Prometheus installation..."
+        kubectl get pods -n prometheus-system | grep prometheus
 
-        until kubectl get pods -A | grep kubeplus | grep -i Running; do echo "Waiting for KubePlus to start.."; sleep 1; kubeplus_pod=`kubectl get pods | grep kubeplus | awk '{print $1}'`; kubectl get pods $kubeplus_pod;  done 
+    - name: Verify OpenCost Installation
+      run: |
+        echo "Verifying OpenCost installation..."
+        kubectl get pods -n opencost | grep opencost
+
+    - name: Verify KubePlus Installation
+      run: |
+        echo "Verifying KubePlus installation..."
+        kubectl get pods -n $KUBEPLUS_NS | grep kubeplus
+
+    - name: Retrieve KubePlus Pod Logs
+      run: |
         kubeplus_pod=`kubectl get pods | grep kubeplus | awk '{print $1}'`
-        echo "helmer logs..."
+        echo "Helmer logs..."
         kubectl logs $kubeplus_pod -c helmer
-        echo "platform-operator logs..."
+        echo "Platform Operator logs..."
         kubectl logs $kubeplus_pod -c platform-operator
-        echo "crd-hook logs..."
+        echo "CRD Hook logs..."
         kubectl logs $kubeplus_pod -c crd-hook
-        kubectl upload chart ./examples/multitenancy/application-hosting/wordpress/wordpress-chart-0.0.3.tgz kubeplus-saas-provider.json
-        echo "Sleeping for 10 seconds before continuing..."
-        sleep 10
+
+    - name: Upload Example Chart
+      run: kubectl upload chart ./examples/multitenancy/application-hosting/wordpress/wordpress-chart-0.0.3.tgz kubeplus-saas-provider.json
+
+    - name: Sleep Before Continuing
+      run: sleep 10
+
+    - name: Deploy WordPress Service Composition
+      run: |
         kubectl create -f ./examples/multitenancy/application-hosting/wordpress/wordpress-service-composition-localchart.yaml --kubeconfig=kubeplus-saas-provider.json
-        until kubectl get crds | grep wordpressservices.platformapi.kubeplus; do echo "Waiting for CRD to be registered.."; sleep 1; done
+
+    - name: Wait for CRD Registration
+      run: |
+        until kubectl get crds | grep wordpressservices.platformapi.kubeplus; do
+          echo "Waiting for CRD to be registered..."
+          sleep 1
+        done
+
+    - name: Deploy Tenant Example
+      run: |
         kubectl create -f ./examples/multitenancy/application-hosting/wordpress/tenant1.yaml --kubeconfig=kubeplus-saas-provider.json
         kubectl get resourcecompositions
         kubectl describe resourcecomposition wordpress-service-composition
-        until kubectl get pods -n wp-tenant1 | grep Running; do echo "Waiting for Application Pods to start.."; sleep 1; done
+
+    - name: Wait for Application Pods to Start
+      run: |
+        until kubectl get pods -n wp-tenant1 | grep Running; do
+          echo "Waiting for Application Pods to start..."
+          sleep 1
+        done
+
+    - name: Interact with Deployed Application
+      run: |
         kubectl appresources WordpressService wp-tenant1 –k kubeplus-saas-provider.json
         kubectl metrics WordpressService wp-tenant1 $KUBEPLUS_NS -k kubeplus-saas-provider.json
+
+    - name: Cleanup Deployed Resources
+      run: |
         kubectl delete wordpressservice wp-tenant1 --kubeconfig=kubeplus-saas-provider.json
         kubectl delete resourcecomposition wordpress-service-composition --kubeconfig=kubeplus-saas-provider.json
-        echo "Running tests..starting in 5 seconds"
-        sleep 5
+
+    - name: Run Unit Tests
+      run: |
         cd tests
         python3 -m venv venv
         source venv/bin/activate

--- a/examples/getting-started.md
+++ b/examples/getting-started.md
@@ -1,0 +1,150 @@
+# Kubeplus
+
+## Getting Started with an example
+
+Let’s look at an example of creating a multi-instance WordPress Service using KubePlus. The WordPress service provider goes through the following steps towards this on their cluster:
+
+1. Create cluster or use an existing cluster. For testing purposes you can create a [minikube](https://minikube.sigs.k8s.io/docs/) or [kind](https://kind.sigs.k8s.io/) cluster:
+
+   `minikube start`
+
+   or
+
+   `kind create cluster`
+
+2. Set the Namespace in which to deploy KubePlus
+
+   `export KUBEPLUS_NS=default`
+
+3. Create provider kubeconfig using provider-kubeconfig.py
+
+   ```sh
+   wget https://raw.githubusercontent.com/cloud-ark/kubeplus/master/requirements.txt
+   wget https://raw.githubusercontent.com/cloud-ark/kubeplus/master/provider-kubeconfig.py
+   python3 -m venv venv
+   source venv/bin/activate
+   pip3 install -r requirements.txt
+   apiserver=`kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'`
+   python3 provider-kubeconfig.py -s $apiserver create $KUBEPLUS_NS
+   deactivate
+   ```
+
+4. Install KubePlus Operator, KubePlus kubectl plugin using the `install.sh` script
+
+   ```sh
+   ./install.sh --kubeplus --kubeplus-plugin
+   ```
+
+5. (Optional) To install opencost
+
+   * With default cost values
+
+      ```sh
+      ./install.sh --opencost --prometheus
+      ```
+
+   * With custom cost values. Please refer the [opencost guide](https://www.opencost.io/docs/configuration/on-prem#custom-pricing-using-the-opencost-helm-chart) for reference
+
+   ```sh
+   wget https://raw.githubusercontent.com/opencost/opencost/develop/configs/default.json
+   ./install.sh --opencost default.json --prometheus
+   ```
+
+6. Create Kubernetes CRD representing WordPress Helm chart.
+
+   *The WordPress Helm chart can be specified as a [public url](./examples/multitenancy/application-hosting/wordpress/wordpress-service-composition.yaml) or can be [available locally](./examples/multitenancy/application-hosting/wordpress/wordpress-service-composition-localchart.yaml).*
+
+   ```sh
+   kubectl create -f https://raw.githubusercontent.com/cloud-ark/kubeplus/master/examples/multitenancy/application-hosting/wordpress/wordpress-service-composition.yaml --kubeconfig=kubeplus-saas-provider.json
+   kubectl get resourcecompositions
+   kubectl describe resourcecomposition wordpress-service-composition
+   ```
+
+   If the status of the `wordpress-service-composition` indicates that the new CRD has been created successfully, verify it:
+
+   ```sh
+   kubectl get crds
+   ```
+
+   You should see `wordpressservices.platformapi.kubeplus` CRD registered.
+
+7. Create WordpressService instance `wp-tenant1`
+
+   ```sh
+   kubectl create -f https://raw.githubusercontent.com/cloud-ark/kubeplus/master/examples/multitenancy/application-hosting/wordpress/tenant1.yaml --kubeconfig=kubeplus-saas-provider.json
+   ```
+
+8. Create WordpressService instance `wp-tenant2`
+
+   ```sh
+   kubectl create -f https://raw.githubusercontent.com/cloud-ark/kubeplus/master/examples/multitenancy/application-hosting/wordpress/tenant2.yaml --kubeconfig=kubeplus-saas-provider.json
+   ```
+
+9. Check created WordpressService instances
+
+   ```sh
+   kubectl get wordpressservices
+
+   NAME             AGE
+   wp-tenant1   86s
+   wp-tenant2   26s
+   ```
+
+10. Check the details of created instance
+
+   ```sh
+   kubectl describe wordpressservices wp-tenant1
+   ```
+
+11.Check created application resources
+
+   * Notice that the `WordpressService` instance resources are deployed in a Namespace `wp-tenant1`, which was created by KubePlus.
+
+   ```sh
+   kubectl appresources WordpressService wp-tenant1 –k kubeplus-saas-provider.json
+
+   NAMESPACE                 KIND                      NAME                      
+   default                   WordpressService          wp-tenant1                
+   wp-tenant1                PersistentVolumeClaim     mysql-pv-claim            
+   wp-tenant1                PersistentVolumeClaim     wp-for-tenant1            
+   wp-tenant1                Service                   wordpress-mysql           
+   wp-tenant1                Service                   wp-for-tenant1            
+   wp-tenant1                Deployment                mysql                     
+   wp-tenant1                Deployment                wp-for-tenant1            
+   wp-tenant1                Pod                       mysql-76d6d9bdfd-2wl2p    
+   wp-tenant1                Pod                       wp-for-tenant1-87c4c954-s2cct 
+   wp-tenant1                NetworkPolicy             allow-external-traffic    
+   wp-tenant1                NetworkPolicy             restrict-cross-ns-traffic 
+   wp-tenant1                ResourceQuota             wordpressservice-wp-tenant1
+   ```
+
+11. Check application resource consumption
+
+   ```sh
+   kubectl metrics WordpressService wp-tenant1 $KUBEPLUS_NS -k kubeplus-saas-provider.json
+
+   ---------------------------------------------------------- 
+   Kubernetes Resources created:
+       Number of Sub-resources: -
+       Number of Pods: 2
+           Number of Containers: 2
+           Number of Nodes: 1
+           Number of Not Running Pods: 0
+   Underlying Physical Resoures consumed:
+       Total CPU(cores): 0.773497m
+       Total MEMORY(bytes): 516.30859375Mi
+       Total Storage(bytes): 40Gi
+       Total Network bytes received: 0
+       Total Network bytes transferred: 0
+   ---------------------------------------------------------- 
+   ```
+
+12. Cleanup
+
+   ```sh
+   kubectl delete wordpressservice wp-tenant1 --kubeconfig=kubeplus-saas-provider.json
+   kubectl delete wordpressservice wp-tenant2 --kubeconfig=kubeplus-saas-provider.json
+   kubectl delete resourcecomposition wordpress-service-composition --kubeconfig=kubeplus-saas-provider.json
+   helm delete kubeplus -n $KUBEPLUS_NS
+   python3 provider-kubeconfig.py delete $KUBEPLUS_NS
+   ```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+# Function to print usage
+usage() {
+    echo "Usage: $0 [--prometheus] [--opencost <opencost config>] [--kubeplus-plugin] [--kubeplus <kubeplus-namespace>]"
+    echo "Example: $0 --prometheus --opencost config.json --kubeplus-plugin --kubeplus kubeplus-namespace"
+    exit 1
+}
+
+# Exit on error
+set -e
+
+# Check if Helm is installed
+if ! command -v helm &> /dev/null; then
+    echo "Error: Helm is not installed. Please install Helm before running this script."
+    exit 1
+fi
+
+# Check if KUBEPLUS_CI is set and is true
+if [ -z "$KUBEPLUS_CI" ]; then
+    KUBEPLUS_CI=false
+fi
+
+# Parse arguments
+TIMEOUT=300
+INSTALL_OPENCOST=false
+INSTALL_PROMETHEUS=false
+INSTALL_KUBEPLUS=false
+INSTALL_KUBEPLUS_PLUGIN=false
+PROMETHEUS_NAMESPACE="prometheus-system"
+OPENCOST_NAMESPACE="opencost"
+KUBEPLUS_NAMESPACE="kubeplus"
+OPENCOST_CONFIG=""
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --opencost)
+            INSTALL_OPENCOST=true
+            if [ -n "$2" ] && [[ "$2" != --* ]]; then
+                OPENCOST_CONFIG="$2"
+                shift
+            fi
+            ;;
+        --prometheus)
+            INSTALL_PROMETHEUS=true
+            ;;
+        --kubeplus-plugin)
+            INSTALL_KUBEPLUS_PLUGIN=true
+            ;;
+        --kubeplus)
+            INSTALL_KUBEPLUS=true
+            if [ -n "$2" ] && [[ "$2" != --* ]]; then
+                KUBEPLUS_NAMESPACE="$2"
+                shift
+            fi
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+# Install Prometheus if the flag is provided
+if $INSTALL_PROMETHEUS; then
+    echo "Installing Prometheus in namespace: $PROMETHEUS_NAMESPACE"
+
+    helm install prometheus --repo https://prometheus-community.github.io/helm-charts prometheus \
+    --namespace prometheus-system --create-namespace \
+    --set prometheus-pushgateway.enabled=false \
+    --set alertmanager.enabled=false \
+    -f https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/prometheus/extraScrapeConfigs.yaml
+
+    elapsed=0
+    while ! kubectl get pods --namespace $PROMETHEUS_NAMESPACE | grep prometheus | grep Running; do
+        if [ $elapsed -ge $TIMEOUT ]; then
+            echo "Timed out waiting for Prometheus to start."
+            exit 1
+        fi
+        echo "Waiting for Prometheus to start.."
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    echo "Prometheus installation completed. Namespace: $PROMETHEUS_NAMESPACE"
+fi
+
+# Install OpenCost if the flag is provided
+if $INSTALL_OPENCOST; then
+    echo "Installing OpenCost in namespace: $OPENCOST_NAMESPACE"
+    kubectl create namespace $OPENCOST_NAMESPACE 2>/dev/null || echo "Namespace $OPENCOST_NAMESPACE already exists"
+
+    if [ -n "$OPENCOST_CONFIG" ]; then
+        helm install opencost --repo https://opencost.github.io/opencost-helm-chart opencost \
+        --namespace $OPENCOST_NAMESPACE -f $OPENCOST_CONFIG
+    else
+        helm install opencost --repo https://opencost.github.io/opencost-helm-chart opencost \
+        --namespace $OPENCOST_NAMESPACE
+    fi
+
+    elapsed=0
+    while ! kubectl get pods --namespace $OPENCOST_NAMESPACE | grep opencost | grep Running; do
+        if [ $elapsed -ge $TIMEOUT ]; then
+            echo "Timed out waiting for OpenCost to start."
+            exit 1
+        fi
+        echo "Waiting for OpenCost to start.."
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    echo "OpenCost installation completed. Namespace: $OPENCOST_NAMESPACE"
+fi
+
+# Function to configure provider kubeconfig for KubePlus
+provider_kubeconfig() {
+    echo "Downloading and setting up provider-kubeconfig.py"
+    kubectl create namespace $KUBEPLUS_NAMESPACE 2>/dev/null || echo "Namespace $KUBEPLUS_NAMESPACE already exists"
+
+    if ! $KUBEPLUS_CI; then
+        wget -q https://raw.githubusercontent.com/cloud-ark/kubeplus/master/requirements.txt || { echo "Failed to download requirements.txt"; exit 1; }
+        wget -q https://raw.githubusercontent.com/cloud-ark/kubeplus/master/provider-kubeconfig.py || { echo "Failed to download provider-kubeconfig.py"; exit 1; }
+    fi
+    python3 -m venv venv
+    source venv/bin/activate
+    pip3 install -r requirements.txt
+    apiserver=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+    python3 provider-kubeconfig.py -s $apiserver create $KUBEPLUS_NAMESPACE
+    deactivate
+}
+
+if $INSTALL_KUBEPLUS_PLUGIN; then
+    echo "Installing KubePlus Plugin"
+    if ! $KUBEPLUS_CI; then
+        wget -q https://github.com/cloud-ark/kubeplus/raw/master/kubeplus-kubectl-plugins.tar.gz || { echo "Failed to download kubeplus-kubectl-plugins.tar.gz"; exit 1; }
+        tar -zxvf kubeplus-kubectl-plugins.tar.gz
+    fi
+    export KUBEPLUS_HOME=$(pwd)
+    export PATH=$KUBEPLUS_HOME/plugins:$PATH
+    kubectl kubeplus commands
+fi
+
+# Install KubePlus if the flag is provided
+if $INSTALL_KUBEPLUS; then
+    provider_kubeconfig
+    echo "Installing KubePlus in namespace: $KUBEPLUS_NAMESPACE"
+
+    if ! $KUBEPLUS_CI; then
+        helm install kubeplus https://github.com/cloud-ark/operatorcharts/raw/master/kubeplus-chart-4.0.0.tgz --kubeconfig=kubeplus-saas-provider.json -n $KUBEPLUS_NAMESPACE
+    else
+        helm install kubeplus ./deploy/kubeplus-chart \
+        --kubeconfig=kubeplus-saas-provider.json \
+        --set MUTATING_WEBHOOK=gcr.io/cloudark-kubeplus/pac-mutating-admission-webhook:latest \
+        --set PLATFORM_OPERATOR=gcr.io/cloudark-kubeplus/platform-operator:latest \
+        --set HELMER=gcr.io/cloudark-kubeplus/helm-pod:latest \
+        --set CRD_REGISTRATION_HELPER=gcr.io/cloudark-kubeplus/kubeconfiggenerator:latest \
+        -n $KUBEPLUS_NAMESPACE
+    fi
+
+    elapsed=0
+    while ! kubectl get pods --namespace $KUBEPLUS_NAMESPACE | grep kubeplus | grep Running; do
+        if [ $elapsed -ge $TIMEOUT ]; then
+            echo "Timed out waiting for KubePlus to start."
+            exit 1
+        fi
+        echo "Waiting for KubePlus to start.."
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "KubePlus has started successfully."
+fi
+
+# Provide additional instructions or notes
+if ! $INSTALL_OPENCOST && ! $INSTALL_PROMETHEUS && ! $INSTALL_KUBEPLUS && ! $INSTALL_KUBEPLUS_PLUGIN; then
+    echo "No installation flags were provided. Please specify at least one installation flag: --opencost, --prometheus, --kubeplus, or --kubeplus-plugin."
+else
+    echo "Installation process completed. Check the status of the deployments using 'kubectl get pods -n <namespace>'."
+fi


### PR DESCRIPTION
## Updates

* Create a script for installing the KubePlus operator and KubePlus kubectl plugin
* Update README.md to include a "Quick Installation" section and move the getting-started example to a separate file to streamline the README
* Add an OpenCost example to the getting-started file
* Update GitHub Actions PR workflow to use the install.sh script for installing the KubePlus operator and kubectl plugin; modularized into distinct steps

## Issues

* https://github.com/cloud-ark/kubeplus/issues/1287