### PR TITLE
feat: Automate Plugin Releases via GitHub Actions

### DIFF
--- a/.github/workflows/release-plugins.yaml
+++ b/.github/workflows/release-plugins.yaml
@@ -1,0 +1,40 @@
+name: Plugins Release (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version number (e.g v1.0.0)"
+        required: true
+      notes:
+        description: "Release notes (optional)"
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create tar file of the plugins folder
+        run: |
+          tar -czvf kubeplus-kubectl-plugins-${{ github.event.inputs.version }}.tar.gz -C plugins .
+
+      - name: Create GitHub release and upload asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NOTES="${{ github.event.inputs.notes }}"
+          if [ -z "$NOTES" ]; then
+            NOTES="Release of kubeplus kubectl plugins version ${{ github.event.inputs.version }}"
+          fi
+
+          gh release create kubeplus-kubectl-plugins-${{ github.event.inputs.version }} \
+            kubeplus-kubectl-plugins-${{ github.event.inputs.version }}.tar.gz \
+            --title "Release kubeplus-kubectl-plugins-${{ github.event.inputs.version }}" \
+            --notes "$NOTES"


### PR DESCRIPTION
### Updates:

-  Introduced a GitHub Actions workflow to automate the release process for the plugins directory.

### How to Use:

- Navigate to the Actions tab in GitHub
- Select  Plugin Release (Manual) workflow
- Click Run workflow, enter the desired version, and execute.

### Test run:

- GHA test run: https://github.com/chiukapoor/kubeplus/actions/runs/13930778381/job/38987100005
- Corresponding release: https://github.com/chiukapoor/kubeplus/releases/tag/plugins-v2.0.0

### Issue:

- Fixes: https://github.com/cloud-ark/kubeplus/issues/1401