### PR TITLE
GitOps example with ArgoCD

### DIFF
--- a/examples/multitenancy/application-hosting/hello-world-argocd/README.md
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/README.md
@@ -1,0 +1,22 @@
+Hello World Argo CD Consumer
+============================
+
+This example captures the consumer-side GitOps input for the KubePlus Hello
+World multi-tenancy flow.
+
+What this example includes
+--------------------------
+
+- The Argo CD `Application` used for the consumer sync
+- Tenant instances of `HelloWorldService`
+- A short `steps.txt` for reproducing the workflow
+
+Important note
+--------------
+
+Argo CD should still sync from the dedicated small repo:
+
+`https://github.com/PatrickBladeeman/hello-world-argocd-consumer`
+
+The files in this folder mirror that repo so the example can be committed and
+documented inside `kubeplus`.

--- a/examples/multitenancy/application-hosting/hello-world-argocd/README.md
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/README.md
@@ -1,12 +1,16 @@
-Hello World Argo CD Consumer
-============================
+Hello World Argo CD
+===================
 
-This example captures the consumer-side GitOps input for the KubePlus Hello
-World multi-tenancy flow.
+This example captures provider-side and consumer-side GitOps inputs for the
+KubePlus Hello World multi-tenancy flow.
 
 What this example includes
 --------------------------
 
+- The Argo CD `AppProject` used for the provider sync
+- A provider-side `ResourceComposition` mirror under `provider/`
+- The Argo CD `Application` used for the provider sync
+- The Argo CD `AppProject` used for the consumer sync
 - The Argo CD `Application` used for the consumer sync
 - Tenant instances of `HelloWorldService`
 - A short `steps.txt` for reproducing the workflow
@@ -14,9 +18,10 @@ What this example includes
 Important note
 --------------
 
-Argo CD should still sync from the dedicated small repo:
+Argo CD should still sync from dedicated small repos:
 
-`https://github.com/PatrickBladeeman/hello-world-argocd-consumer`
+- one provider repo for the `ResourceComposition`
+- one consumer repo for the tenant instances
 
-The files in this folder mirror that repo so the example can be committed and
-documented inside `kubeplus`.
+The files in this folder are mirrors/templates so the example can be committed
+and documented inside `kubeplus`.

--- a/examples/multitenancy/application-hosting/hello-world-argocd/README.md
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/README.md
@@ -1,0 +1,30 @@
+Hello World Argo CD
+===================
+
+This example captures provider-side and consumer-side GitOps inputs for the
+KubePlus Hello World multi-tenancy flow.
+
+What this example includes
+--------------------------
+
+- The Argo CD `AppProject` used for the provider sync
+- A provider-side `ResourceComposition` mirror under `provider/`
+- The Argo CD `Application` used for the provider sync
+- The Argo CD `AppProject` used for the consumer sync
+- The Argo CD `Application` used for the consumer sync
+- Tenant instances of `HelloWorldService`
+- A short `steps.txt` for reproducing the workflow
+
+Important note
+--------------
+
+Argo CD should sync from a small examples repo rather than from the full
+`kubeplus` source repo. In this layout, both the provider and consumer Argo CD
+applications point at this same `kubeplus-examples` repo, but use different
+subpaths:
+
+- `multitenancy/application-hosting/hello-world-argocd/provider`
+- `multitenancy/application-hosting/hello-world-argocd/tenants`
+
+This keeps the GitOps source compact while still allowing the full example to
+live in one official examples repository.

--- a/examples/multitenancy/application-hosting/hello-world-argocd/argocd-consumer-app.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/argocd-consumer-app.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: kubeplus-tenants
   source:
-    repoURL: https://github.com/PatrickBladeeman/hello-world-argocd-consumer
+    repoURL: https://github.com/<org>/hello-world-argocd-consumer
     targetRevision: main
     path: tenants
   destination:

--- a/examples/multitenancy/application-hosting/hello-world-argocd/argocd-consumer-app.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/argocd-consumer-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kubeplus-hello-world-consumer
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/PatrickBladeeman/hello-world-argocd-consumer
+    targetRevision: main
+    path: tenants
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/multitenancy/application-hosting/hello-world-argocd/argocd-consumer-app.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/argocd-consumer-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kubeplus-hello-world-consumer
+  namespace: argocd
+spec:
+  project: helloworld-tenants
+  source:
+    repoURL: https://github.com/cloud-ark/kubeplus-examples
+    targetRevision: main
+    path: multitenancy/application-hosting/hello-world-argocd/tenants
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/multitenancy/application-hosting/hello-world-argocd/argocd-consumer-project.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/argocd-consumer-project.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: kubeplus-tenants
+  namespace: argocd
+spec:
+  sourceRepos:
+    - '*'
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: default
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinationServiceAccounts:
+    - server: https://kubernetes.default.svc
+      namespace: default
+      defaultServiceAccount: kubeplus-saas-consumer

--- a/examples/multitenancy/application-hosting/hello-world-argocd/argocd-consumer-project.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/argocd-consumer-project.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: helloworld-tenants
+  namespace: argocd
+spec:
+  sourceRepos:
+    - '*'
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: default
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinationServiceAccounts:
+    - server: https://kubernetes.default.svc
+      namespace: default
+      defaultServiceAccount: kubeplus-saas-consumer

--- a/examples/multitenancy/application-hosting/hello-world-argocd/argocd-provider-app.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/argocd-provider-app.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: kubeplus-provider
   source:
-    repoURL: https://github.com/PatrickBladeeman/hello-world-argocd-provider
+    repoURL: https://github.com/<org>/hello-world-argocd-provider
     targetRevision: main
     path: provider
   destination:

--- a/examples/multitenancy/application-hosting/hello-world-argocd/argocd-provider-app.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/argocd-provider-app.yaml
@@ -1,14 +1,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: kubeplus-hello-world-consumer
+  name: kubeplus-hello-world-provider
   namespace: argocd
 spec:
-  project: kubeplus-tenants
+  project: kubeplus-provider
   source:
-    repoURL: https://github.com/PatrickBladeeman/hello-world-argocd-consumer
+    repoURL: https://github.com/PatrickBladeeman/hello-world-argocd-provider
     targetRevision: main
-    path: tenants
+    path: provider
   destination:
     server: https://kubernetes.default.svc
     namespace: default

--- a/examples/multitenancy/application-hosting/hello-world-argocd/argocd-provider-app.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/argocd-provider-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kubeplus-hello-world-provider
+  namespace: argocd
+spec:
+  project: helloworld-provider
+  source:
+    repoURL: https://github.com/cloud-ark/kubeplus-examples
+    targetRevision: main
+    path: multitenancy/application-hosting/hello-world-argocd/provider
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/multitenancy/application-hosting/hello-world-argocd/argocd-provider-project.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/argocd-provider-project.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: kubeplus-provider
+  namespace: argocd
+spec:
+  sourceRepos:
+    - '*'
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: default
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinationServiceAccounts:
+    - server: https://kubernetes.default.svc
+      namespace: default
+      defaultServiceAccount: kubeplus-saas-provider

--- a/examples/multitenancy/application-hosting/hello-world-argocd/argocd-provider-project.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/argocd-provider-project.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: helloworld-provider
+  namespace: argocd
+spec:
+  sourceRepos:
+    - '*'
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: default
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinationServiceAccounts:
+    - server: https://kubernetes.default.svc
+      namespace: default
+      defaultServiceAccount: kubeplus-saas-provider

--- a/examples/multitenancy/application-hosting/hello-world-argocd/provider/hello-world-service-composition.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/provider/hello-world-service-composition.yaml
@@ -1,0 +1,34 @@
+apiVersion: workflows.kubeplus/v1alpha1
+kind: ResourceComposition
+metadata:
+  name: hello-world-service-composition
+spec:
+  newResource:
+    resource:
+      kind: HelloWorldService
+      group: platformapi.kubeplus
+      version: v1alpha1
+      plural: helloworldservices
+    chartURL: https://github.com/cloud-ark/kubeplus/blob/master/examples/multitenancy/hello-world/hello-world-chart-0.0.3.tgz?raw=true
+    chartName: hello-world-chart
+  respolicy:
+    apiVersion: workflows.kubeplus/v1alpha1
+    kind: ResourcePolicy
+    metadata:
+      name: hello-world-service-policy
+    spec:
+      resource:
+        kind: HelloWorldService
+        group: platformapi.kubeplus
+        version: v1alpha1
+  resmonitor:
+    apiVersion: workflows.kubeplus/v1alpha1
+    kind: ResourceMonitor
+    metadata:
+      name: hello-world-service-monitor
+    spec:
+      resource:
+        kind: HelloWorldService
+        group: platformapi.kubeplus
+        version: v1alpha1
+      monitorRelationships: all

--- a/examples/multitenancy/application-hosting/hello-world-argocd/provider/kustomization.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/provider/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - hello-world-service-composition.yaml

--- a/examples/multitenancy/application-hosting/hello-world-argocd/steps.txt
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/steps.txt
@@ -1,0 +1,67 @@
+Hello World Argo CD Consumer Flow
+--------------------------------
+
+This example keeps the provider setup manual and uses Argo CD only for the
+consumer-side `HelloWorldService` instances.
+
+Important:
+- Argo CD should sync from a dedicated small consumer repo, not directly from
+  the full `kubeplus` repo.
+- The files in this folder are meant to be copied into that consumer repo.
+
+Prerequisites
+-------------
+
+- KubePlus is installed and running
+- Argo CD is installed and running
+- A valid provider kubeconfig is available at:
+  `examples/multitenancy/hello-world/provider.conf`
+
+Steps
+-----
+
+1. Register the `HelloWorldService` API as the provider:
+
+   `kubectl create -f <kubeplus-repo>/examples/multitenancy/hello-world/hello-world-service-composition.yaml --kubeconfig=<kubeplus-repo>/examples/multitenancy/hello-world/provider.conf`
+
+2. Wait for the CRD:
+
+   `until kubectl get crds --kubeconfig=<kubeplus-repo>/examples/multitenancy/hello-world/provider.conf | grep helloworldservices.platformapi.kubeplus; do echo "Waiting for HelloWorldService CRD..."; sleep 1; done`
+
+3. Create a dedicated consumer Git repo for the tenant manifests:
+
+   - copy `argocd-consumer-app.yaml` and the `tenants/` folder from this
+     example into `<hello-world-argocd-consumer-repo>`
+   - update `repoURL` in `argocd-consumer-app.yaml` so it points to that repo
+   - commit and push the repo contents
+
+4. Apply the consumer Argo CD app:
+
+   `kubectl apply -f <hello-world-argocd-example-dir>/argocd-consumer-app.yaml -n argocd`
+
+5. Verify the initial sync:
+
+   `kubectl get application kubeplus-hello-world-consumer -n argocd`
+   `kubectl get helloworldservices.platformapi.kubeplus -n default`
+   `kubectl get pods -n hs1`
+
+6. Test GitOps changes by editing the dedicated consumer repo and pushing:
+
+   `cd <hello-world-argocd-consumer-repo>`
+   `git add tenants/hs1.yaml tenants/hs2.yaml tenants/kustomization.yaml`
+   `git commit -m "Update hello world tenants"`
+   `git push`
+
+7. Watch Argo CD reconcile:
+
+   `kubectl get application kubeplus-hello-world-consumer -n argocd -w`
+   `kubectl get helloworldservices.platformapi.kubeplus -n default`
+   `kubectl get pods -n hs1`
+   `kubectl get pods -n hs2`
+
+Expected result
+---------------
+
+- `hs1` runs with 2 replicas
+- `hs2` is created as a second tenant instance
+- Argo CD shows the consumer application as `Synced`

--- a/examples/multitenancy/application-hosting/hello-world-argocd/steps.txt
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/steps.txt
@@ -16,14 +16,33 @@ Prerequisites
 -------------
 
 - KubePlus is installed and running
-- Argo CD is installed and running
 - The `kubeplus-saas-provider` and `kubeplus-saas-consumer` service accounts
   already exist, along with working `provider.conf` and `consumer.conf`
 
 Steps
 -----
 
-1. Create fresh provider and consumer kubeconfigs so the provider and consumer
+1. Install Argo CD:
+
+   `kubectl get namespace argocd >/dev/null 2>&1 || kubectl create namespace argocd`
+   `kubectl apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml`
+   `kubectl rollout status deployment/argocd-server -n argocd --timeout=180s`
+   `kubectl get pods -n argocd`
+
+2. Access the Argo CD UI:
+
+   `kubectl port-forward svc/argocd-server -n argocd 8080:443`
+   `kubectl get secret argocd-initial-admin-secret -n argocd -o jsonpath='{.data.password}' | base64 -d; echo`
+
+   Open:
+
+   `https://localhost:8080`
+
+   Username:
+
+   `admin`
+
+3. Create fresh provider and consumer kubeconfigs so the provider and consumer
    service accounts exist and can be used:
 
    `cd <kubeplus-repo>`
@@ -33,50 +52,50 @@ Steps
    `cp kubeplus-saas-provider.json <kubeplus-repo>/examples/multitenancy/hello-world/provider.conf`
    `kubectl retrieve kubeconfig consumer -s "$apiserver" > <kubeplus-repo>/examples/multitenancy/hello-world/consumer.conf`
 
-2. Enable Argo CD sync impersonation:
+4. Enable Argo CD sync impersonation:
 
    `kubectl patch cm argocd-cm -n argocd --type merge -p '{"data":{"application.sync.impersonation.enabled":"true"}}'`
    `kubectl rollout restart statefulset argocd-application-controller -n argocd`
 
-3. Apply the Argo CD projects:
+5. Apply the Argo CD projects:
 
    `kubectl apply -f <hello-world-argocd-example-dir>/argocd-provider-project.yaml -n argocd`
    `kubectl apply -f <hello-world-argocd-example-dir>/argocd-consumer-project.yaml -n argocd`
 
-4. Create a dedicated provider Git repo for the provider manifests:
+6. Create a dedicated provider Git repo for the provider manifests:
 
    - copy `argocd-provider-app.yaml` and the `provider/` folder from this
      example into `<hello-world-argocd-provider-repo>`
    - update `repoURL` in `argocd-provider-app.yaml` so it points to that repo
    - commit and push the repo contents
 
-5. Apply the provider Argo CD app:
+7. Apply the provider Argo CD app:
 
    `kubectl apply -f <hello-world-argocd-example-dir>/argocd-provider-app.yaml -n argocd`
 
-6. Wait for the CRD:
+8. Wait for the CRD:
 
    `until kubectl get crds | grep helloworldservices.platformapi.kubeplus; do echo "Waiting for HelloWorldService CRD..."; sleep 1; done`
 
-7. Create a dedicated consumer Git repo for the tenant manifests:
+9. Create a dedicated consumer Git repo for the tenant manifests:
 
    - copy `argocd-consumer-app.yaml` and the `tenants/` folder from this
      example into `<hello-world-argocd-consumer-repo>`
    - update `repoURL` in `argocd-consumer-app.yaml` so it points to that repo
    - commit and push the repo contents
 
-8. Apply the consumer Argo CD app:
+10. Apply the consumer Argo CD app:
 
    `kubectl apply -f <hello-world-argocd-example-dir>/argocd-consumer-app.yaml -n argocd`
 
-9. Verify the initial sync:
+11. Verify the initial sync:
 
    `kubectl get application kubeplus-hello-world-provider -n argocd`
    `kubectl get application kubeplus-hello-world-consumer -n argocd`
    `kubectl get helloworldservices.platformapi.kubeplus -n default`
    `kubectl get pods -n hs1`
 
-10. Test provider-side sync by modifying the `ResourceComposition` in the
+12. Test provider-side sync by modifying the `ResourceComposition` in the
    provider repo and pushing:
 
    `cd <hello-world-argocd-provider-repo>`
@@ -97,14 +116,14 @@ PY`
    `kubectl get application kubeplus-hello-world-provider -n argocd`
    `kubectl get resourcecomposition hello-world-service-composition -n default -o yaml`
 
-11. Test GitOps changes by editing the dedicated consumer repo and pushing:
+13. Test GitOps changes by editing the dedicated consumer repo and pushing:
 
    `cd <hello-world-argocd-consumer-repo>`
    `git add tenants/hs1.yaml tenants/hs2.yaml tenants/kustomization.yaml`
    `git commit -m "Update hello world tenants"`
    `git push`
 
-12. Watch Argo CD reconcile:
+14. Watch Argo CD reconcile:
 
    `kubectl get application kubeplus-hello-world-provider -n argocd -w`
    `kubectl get application kubeplus-hello-world-consumer -n argocd -w`

--- a/examples/multitenancy/application-hosting/hello-world-argocd/steps.txt
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/steps.txt
@@ -18,73 +18,93 @@ Prerequisites
 - KubePlus is installed and running
 - Argo CD is installed and running
 - The `kubeplus-saas-provider` and `kubeplus-saas-consumer` service accounts
-  already exist
+  already exist, along with working `provider.conf` and `consumer.conf`
 
 Steps
 -----
 
-1. Enable Argo CD sync impersonation:
+1. Create fresh provider and consumer kubeconfigs so the provider and consumer
+   service accounts exist and can be used:
+
+   `cd <kubeplus-repo>`
+   `export KUBEPLUS_NS=default`
+   `apiserver=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')`
+   `python3 provider-kubeconfig.py -s "$apiserver" create "$KUBEPLUS_NS"`
+   `cp kubeplus-saas-provider.json <kubeplus-repo>/examples/multitenancy/hello-world/provider.conf`
+   `kubectl retrieve kubeconfig consumer -s "$apiserver" > <kubeplus-repo>/examples/multitenancy/hello-world/consumer.conf`
+
+2. Enable Argo CD sync impersonation:
 
    `kubectl patch cm argocd-cm -n argocd --type merge -p '{"data":{"application.sync.impersonation.enabled":"true"}}'`
    `kubectl rollout restart statefulset argocd-application-controller -n argocd`
 
-2. Apply the Argo CD projects:
+3. Apply the Argo CD projects:
 
    `kubectl apply -f <hello-world-argocd-example-dir>/argocd-provider-project.yaml -n argocd`
    `kubectl apply -f <hello-world-argocd-example-dir>/argocd-consumer-project.yaml -n argocd`
 
-3. Create a dedicated provider Git repo for the provider manifests:
+4. Create a dedicated provider Git repo for the provider manifests:
 
    - copy `argocd-provider-app.yaml` and the `provider/` folder from this
      example into `<hello-world-argocd-provider-repo>`
    - update `repoURL` in `argocd-provider-app.yaml` so it points to that repo
    - commit and push the repo contents
 
-4. Apply the provider Argo CD app:
+5. Apply the provider Argo CD app:
 
    `kubectl apply -f <hello-world-argocd-example-dir>/argocd-provider-app.yaml -n argocd`
 
-5. Wait for the CRD:
+6. Wait for the CRD:
 
    `until kubectl get crds | grep helloworldservices.platformapi.kubeplus; do echo "Waiting for HelloWorldService CRD..."; sleep 1; done`
 
-6. Create a dedicated consumer Git repo for the tenant manifests:
+7. Create a dedicated consumer Git repo for the tenant manifests:
 
    - copy `argocd-consumer-app.yaml` and the `tenants/` folder from this
      example into `<hello-world-argocd-consumer-repo>`
    - update `repoURL` in `argocd-consumer-app.yaml` so it points to that repo
    - commit and push the repo contents
 
-7. Apply the consumer Argo CD app:
+8. Apply the consumer Argo CD app:
 
    `kubectl apply -f <hello-world-argocd-example-dir>/argocd-consumer-app.yaml -n argocd`
 
-8. Verify the initial sync:
+9. Verify the initial sync:
 
    `kubectl get application kubeplus-hello-world-provider -n argocd`
    `kubectl get application kubeplus-hello-world-consumer -n argocd`
    `kubectl get helloworldservices.platformapi.kubeplus -n default`
    `kubectl get pods -n hs1`
 
-9. Test provider-side sync by modifying the `ResourceComposition` in the
+10. Test provider-side sync by modifying the `ResourceComposition` in the
    provider repo and pushing:
 
-   - add a harmless annotation in
-     `provider/hello-world-service-composition.yaml`, for example:
-     `demo.kubeplus.dev/provider-sync-test: "2026-04-21-a"`
-   - commit and push the provider repo
-   - verify:
-     `kubectl get application kubeplus-hello-world-provider -n argocd`
-     `kubectl get resourcecomposition hello-world-service-composition -n default -o yaml`
+   `cd <hello-world-argocd-provider-repo>`
+   `python3 - <<'PY'
+from pathlib import Path
+p = Path("provider/hello-world-service-composition.yaml")
+s = p.read_text()
+old = "metadata:\\n  name: hello-world-service-composition\\n"
+new = old + "  annotations:\\n    demo.kubeplus.dev/provider-sync-test: \\"2026-04-21-a\\"\\n"
+if "demo.kubeplus.dev/provider-sync-test" not in s:
+    s = s.replace(old, new, 1)
+p.write_text(s)
+PY`
+   `git add provider/hello-world-service-composition.yaml`
+   `git commit -m "Test hello world provider Argo CD sync"`
+   `git push`
+   `kubectl annotate application kubeplus-hello-world-provider -n argocd argocd.argoproj.io/refresh=hard --overwrite`
+   `kubectl get application kubeplus-hello-world-provider -n argocd`
+   `kubectl get resourcecomposition hello-world-service-composition -n default -o yaml`
 
-10. Test GitOps changes by editing the dedicated consumer repo and pushing:
+11. Test GitOps changes by editing the dedicated consumer repo and pushing:
 
    `cd <hello-world-argocd-consumer-repo>`
    `git add tenants/hs1.yaml tenants/hs2.yaml tenants/kustomization.yaml`
    `git commit -m "Update hello world tenants"`
    `git push`
 
-11. Watch Argo CD reconcile:
+12. Watch Argo CD reconcile:
 
    `kubectl get application kubeplus-hello-world-provider -n argocd -w`
    `kubectl get application kubeplus-hello-world-consumer -n argocd -w`

--- a/examples/multitenancy/application-hosting/hello-world-argocd/steps.txt
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/steps.txt
@@ -1,59 +1,92 @@
-Hello World Argo CD Consumer Flow
---------------------------------
+Hello World Argo CD Flow
+------------------------
 
-This example keeps the provider setup manual and uses Argo CD only for the
-consumer-side `HelloWorldService` instances.
+This example uses Argo CD for both the provider-side `ResourceComposition` and
+the consumer-side `HelloWorldService` instances.
 
 Important:
-- Argo CD should sync from a dedicated small consumer repo, not directly from
-  the full `kubeplus` repo.
-- The files in this folder are meant to be copied into that consumer repo.
+- Argo CD should sync from dedicated small repos, not directly from the full
+  `kubeplus` repo.
+- The `provider/` folder and `argocd-provider-app.yaml` are meant to be copied
+  into a small provider repo.
+- The `tenants/` folder and `argocd-consumer-app.yaml` are meant to be copied
+  into a small consumer repo.
 
 Prerequisites
 -------------
 
 - KubePlus is installed and running
 - Argo CD is installed and running
-- A valid provider kubeconfig is available at:
-  `examples/multitenancy/hello-world/provider.conf`
+- The `kubeplus-saas-provider` and `kubeplus-saas-consumer` service accounts
+  already exist
 
 Steps
 -----
 
-1. Register the `HelloWorldService` API as the provider:
+1. Enable Argo CD sync impersonation:
 
-   `kubectl create -f <kubeplus-repo>/examples/multitenancy/hello-world/hello-world-service-composition.yaml --kubeconfig=<kubeplus-repo>/examples/multitenancy/hello-world/provider.conf`
+   `kubectl patch cm argocd-cm -n argocd --type merge -p '{"data":{"application.sync.impersonation.enabled":"true"}}'`
+   `kubectl rollout restart statefulset argocd-application-controller -n argocd`
 
-2. Wait for the CRD:
+2. Apply the Argo CD projects:
 
-   `until kubectl get crds --kubeconfig=<kubeplus-repo>/examples/multitenancy/hello-world/provider.conf | grep helloworldservices.platformapi.kubeplus; do echo "Waiting for HelloWorldService CRD..."; sleep 1; done`
+   `kubectl apply -f <hello-world-argocd-example-dir>/argocd-provider-project.yaml -n argocd`
+   `kubectl apply -f <hello-world-argocd-example-dir>/argocd-consumer-project.yaml -n argocd`
 
-3. Create a dedicated consumer Git repo for the tenant manifests:
+3. Create a dedicated provider Git repo for the provider manifests:
+
+   - copy `argocd-provider-app.yaml` and the `provider/` folder from this
+     example into `<hello-world-argocd-provider-repo>`
+   - update `repoURL` in `argocd-provider-app.yaml` so it points to that repo
+   - commit and push the repo contents
+
+4. Apply the provider Argo CD app:
+
+   `kubectl apply -f <hello-world-argocd-example-dir>/argocd-provider-app.yaml -n argocd`
+
+5. Wait for the CRD:
+
+   `until kubectl get crds | grep helloworldservices.platformapi.kubeplus; do echo "Waiting for HelloWorldService CRD..."; sleep 1; done`
+
+6. Create a dedicated consumer Git repo for the tenant manifests:
 
    - copy `argocd-consumer-app.yaml` and the `tenants/` folder from this
      example into `<hello-world-argocd-consumer-repo>`
    - update `repoURL` in `argocd-consumer-app.yaml` so it points to that repo
    - commit and push the repo contents
 
-4. Apply the consumer Argo CD app:
+7. Apply the consumer Argo CD app:
 
    `kubectl apply -f <hello-world-argocd-example-dir>/argocd-consumer-app.yaml -n argocd`
 
-5. Verify the initial sync:
+8. Verify the initial sync:
 
+   `kubectl get application kubeplus-hello-world-provider -n argocd`
    `kubectl get application kubeplus-hello-world-consumer -n argocd`
    `kubectl get helloworldservices.platformapi.kubeplus -n default`
    `kubectl get pods -n hs1`
 
-6. Test GitOps changes by editing the dedicated consumer repo and pushing:
+9. Test provider-side sync by modifying the `ResourceComposition` in the
+   provider repo and pushing:
+
+   - add a harmless annotation in
+     `provider/hello-world-service-composition.yaml`, for example:
+     `demo.kubeplus.dev/provider-sync-test: "2026-04-21-a"`
+   - commit and push the provider repo
+   - verify:
+     `kubectl get application kubeplus-hello-world-provider -n argocd`
+     `kubectl get resourcecomposition hello-world-service-composition -n default -o yaml`
+
+10. Test GitOps changes by editing the dedicated consumer repo and pushing:
 
    `cd <hello-world-argocd-consumer-repo>`
    `git add tenants/hs1.yaml tenants/hs2.yaml tenants/kustomization.yaml`
    `git commit -m "Update hello world tenants"`
    `git push`
 
-7. Watch Argo CD reconcile:
+11. Watch Argo CD reconcile:
 
+   `kubectl get application kubeplus-hello-world-provider -n argocd -w`
    `kubectl get application kubeplus-hello-world-consumer -n argocd -w`
    `kubectl get helloworldservices.platformapi.kubeplus -n default`
    `kubectl get pods -n hs1`
@@ -62,6 +95,7 @@ Steps
 Expected result
 ---------------
 
+- The provider app syncs the updated `ResourceComposition`
 - `hs1` runs with 2 replicas
 - `hs2` is created as a second tenant instance
-- Argo CD shows the consumer application as `Synced`
+- Argo CD shows both provider and consumer applications as `Synced`

--- a/examples/multitenancy/application-hosting/hello-world-argocd/steps.txt
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/steps.txt
@@ -1,0 +1,142 @@
+Hello World Argo CD Flow
+------------------------
+
+This example uses Argo CD for both the provider-side `ResourceComposition` and
+the consumer-side `HelloWorldService` instances.
+
+Important:
+- Argo CD should sync from this smaller `kubeplus-examples` repo, not directly
+  from the full `kubeplus` repo.
+- The provider and consumer Argo CD applications in this example both point to
+  this repo, but use different subpaths.
+
+Prerequisites
+-------------
+
+- KubePlus is installed and running
+- The `kubeplus-saas-provider` and `kubeplus-saas-consumer` service accounts
+  already exist, along with working `provider.conf` and `consumer.conf`
+
+Steps
+-----
+
+1. Install Argo CD:
+
+   kubectl get namespace argocd >/dev/null 2>&1 || kubectl create namespace argocd
+   kubectl apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+   kubectl rollout status deployment/argocd-server -n argocd --timeout=180s
+   kubectl get pods -n argocd
+
+2. Access the Argo CD UI:
+
+   kubectl port-forward svc/argocd-server -n argocd 8080:443
+   kubectl get secret argocd-initial-admin-secret -n argocd -o jsonpath='{.data.password}' | base64 -d; echo
+
+   Open:
+
+   https://localhost:8080
+
+   Username:
+
+   admin
+
+3. Create fresh provider and consumer kubeconfigs so the provider and consumer
+   service accounts exist and can be used:
+
+   cd <kubeplus-repo>
+   export KUBEPLUS_NS=default
+   apiserver=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+   python3 provider-kubeconfig.py -s "$apiserver" create "$KUBEPLUS_NS"
+   cp kubeplus-saas-provider.json <kubeplus-repo>/examples/multitenancy/hello-world/provider.conf
+   kubectl retrieve kubeconfig consumer -s "$apiserver" > <kubeplus-repo>/examples/multitenancy/hello-world/consumer.conf
+
+4. Enable Argo CD sync impersonation:
+
+   kubectl patch cm argocd-cm -n argocd --type merge -p '{"data":{"application.sync.impersonation.enabled":"true"}}'
+   kubectl rollout restart statefulset argocd-application-controller -n argocd
+
+5. Apply the Argo CD projects:
+
+   kubectl apply -f <hello-world-argocd-example-dir>/argocd-provider-project.yaml -n argocd
+   kubectl apply -f <hello-world-argocd-example-dir>/argocd-consumer-project.yaml -n argocd
+
+6. Clone or fork the `kubeplus-examples` repo and update both Argo CD
+   applications so `repoURL` points to that repo:
+
+   git clone https://github.com/cloud-ark/kubeplus-examples.git
+
+   Update:
+
+   - `argocd-provider-app.yaml`
+   - `argocd-consumer-app.yaml`
+
+   so both `repoURL` values point to your `kubeplus-examples` repo.
+
+7. Apply the provider Argo CD app:
+
+   kubectl apply -f <hello-world-argocd-example-dir>/argocd-provider-app.yaml -n argocd
+
+8. Wait for the CRD:
+
+   until kubectl get crds | grep helloworldservices.platformapi.kubeplus; do echo "Waiting for HelloWorldService CRD..."; sleep 1; done
+
+9. Apply the consumer Argo CD app:
+
+   kubectl apply -f <hello-world-argocd-example-dir>/argocd-consumer-app.yaml -n argocd
+
+10. Verify the initial sync:
+
+   kubectl get application kubeplus-hello-world-provider -n argocd
+   kubectl get application kubeplus-hello-world-consumer -n argocd
+   kubectl get helloworldservices.platformapi.kubeplus -n default
+   kubectl get pods -n hs1
+
+11. Test provider-side sync by modifying the `ResourceComposition` in the
+   `kubeplus-examples` repo and pushing:
+
+   cd <kubeplus-examples-repo>
+
+   Edit:
+
+   multitenancy/application-hosting/hello-world-argocd/provider/hello-world-service-composition.yaml
+
+   Add this annotation under `metadata`:
+
+   annotations:
+     demo.kubeplus.dev/provider-sync-test: "2026-04-21-a"
+
+   git add multitenancy/application-hosting/hello-world-argocd/provider/hello-world-service-composition.yaml
+   git commit -m "Test hello world provider Argo CD sync"
+   git push
+
+   The hard refresh tells Argo CD to invalidate its cached Git and manifest
+   state so the provider application immediately reconciles the pushed
+   `ResourceComposition` change during this test.
+
+   kubectl annotate application kubeplus-hello-world-provider -n argocd argocd.argoproj.io/refresh=hard --overwrite
+   kubectl get application kubeplus-hello-world-provider -n argocd
+   kubectl get resourcecomposition hello-world-service-composition -n default -o yaml
+
+12. Test GitOps changes by editing the tenant manifests in
+   `kubeplus-examples` and pushing:
+
+   cd <kubeplus-examples-repo>
+   git add multitenancy/application-hosting/hello-world-argocd/tenants/hs1.yaml multitenancy/application-hosting/hello-world-argocd/tenants/hs2.yaml multitenancy/application-hosting/hello-world-argocd/tenants/kustomization.yaml
+   git commit -m "Update hello world tenants"
+   git push
+
+13. Watch Argo CD reconcile:
+
+   kubectl get application kubeplus-hello-world-provider -n argocd -w
+   kubectl get application kubeplus-hello-world-consumer -n argocd -w
+   kubectl get helloworldservices.platformapi.kubeplus -n default
+   kubectl get pods -n hs1
+   kubectl get pods -n hs2
+
+Expected result
+---------------
+
+- The provider app syncs the updated `ResourceComposition`
+- `hs1` runs with 2 replicas
+- `hs2` is created as a second tenant instance
+- Argo CD shows both provider and consumer applications as `Synced`

--- a/examples/multitenancy/application-hosting/hello-world-argocd/tenants/hs1.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/tenants/hs1.yaml
@@ -1,0 +1,7 @@
+apiVersion: platformapi.kubeplus/v1alpha1
+kind: HelloWorldService
+metadata:
+  name: hs1
+spec:
+  greeting: Hello hello hello
+  replicas: 2

--- a/examples/multitenancy/application-hosting/hello-world-argocd/tenants/hs2.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/tenants/hs2.yaml
@@ -1,0 +1,7 @@
+apiVersion: platformapi.kubeplus/v1alpha1
+kind: HelloWorldService
+metadata:
+  name: hs2
+spec:
+  greeting: Hello from hs2
+  replicas: 1

--- a/examples/multitenancy/application-hosting/hello-world-argocd/tenants/kustomization.yaml
+++ b/examples/multitenancy/application-hosting/hello-world-argocd/tenants/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - hs1.yaml
+  - hs2.yaml

--- a/examples/multitenancy/application-hosting/wordpress-argocd/argocd-provider-app.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/argocd-provider-app.yaml
@@ -6,12 +6,12 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/PatrickBladeeman/kubeplusL
+    repoURL: https://github.com/PatrickBladeeman/kubeplus
     targetRevision: master
     path: examples/multitenancy/application-hosting/wordpress-argocd/provider
   destination:
     server: https://kubernetes.default.svc
-    namespace: REPLACE_WITH_KUBEPLUS_NAMESPACE
+    namespace: default
   syncPolicy:
     automated:
       prune: true

--- a/examples/multitenancy/application-hosting/wordpress-argocd/argocd-provider-app.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/argocd-provider-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kubeplus-wordpress-provider
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/PatrickBladeeman/kubeplusL
+    targetRevision: master
+    path: examples/multitenancy/application-hosting/wordpress-argocd/provider
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: REPLACE_WITH_KUBEPLUS_NAMESPACE
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/multitenancy/application-hosting/wordpress-argocd/argocd-provider-app.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/argocd-provider-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kubeplus-wordpress-provider
+  namespace: argocd
+spec:
+  project: wordpress-provider
+  source:
+    repoURL: https://github.com/cloud-ark/kubeplus-examples
+    targetRevision: main
+    path: multitenancy/application-hosting/wordpress-argocd/provider
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/multitenancy/application-hosting/wordpress-argocd/argocd-provider-project.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/argocd-provider-project.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: wordpress-provider
+  namespace: argocd
+spec:
+  sourceRepos:
+    - '*'
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: default
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinationServiceAccounts:
+    - server: https://kubernetes.default.svc
+      namespace: default
+      defaultServiceAccount: kubeplus-saas-provider

--- a/examples/multitenancy/application-hosting/wordpress-argocd/argocd-tenants-app.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/argocd-tenants-app.yaml
@@ -6,12 +6,12 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: REPLACE_WITH_GIT_REPO_URL
-    targetRevision: REPLACE_WITH_GIT_TARGET_REVISION
+    repoURL: https://github.com/PatrickBladeeman/kubeplus
+    targetRevision: master
     path: examples/multitenancy/application-hosting/wordpress-argocd/tenants
   destination:
     server: https://kubernetes.default.svc
-    namespace: REPLACE_WITH_KUBEPLUS_NAMESPACE
+    namespace: default
   syncPolicy:
     automated:
       prune: true

--- a/examples/multitenancy/application-hosting/wordpress-argocd/argocd-tenants-app.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/argocd-tenants-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kubeplus-wordpress-tenants
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: REPLACE_WITH_GIT_REPO_URL
+    targetRevision: REPLACE_WITH_GIT_TARGET_REVISION
+    path: examples/multitenancy/application-hosting/wordpress-argocd/tenants
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: REPLACE_WITH_KUBEPLUS_NAMESPACE
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/multitenancy/application-hosting/wordpress-argocd/argocd-tenants-app.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/argocd-tenants-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kubeplus-wordpress-tenants
+  namespace: argocd
+spec:
+  project: wordpress-tenants
+  source:
+    repoURL: https://github.com/cloud-ark/kubeplus-examples
+    targetRevision: main
+    path: multitenancy/application-hosting/wordpress-argocd/tenants
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/multitenancy/application-hosting/wordpress-argocd/argocd-tenants-project.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/argocd-tenants-project.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: wordpress-tenants
+  namespace: argocd
+spec:
+  sourceRepos:
+    - '*'
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: default
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinationServiceAccounts:
+    - server: https://kubernetes.default.svc
+      namespace: default
+      defaultServiceAccount: kubeplus-saas-consumer

--- a/examples/multitenancy/application-hosting/wordpress-argocd/provider/kustomization.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/provider/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - wordpress-service-composition.yaml

--- a/examples/multitenancy/application-hosting/wordpress-argocd/provider/wordpress-service-composition.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/provider/wordpress-service-composition.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   newResource:
     resource:
-      kind: GitopsWordpressService
+      kind: GitopsWPService
       group: platformapi.kubeplus
       version: v1alpha1
-      plural: gitopswordpressservices
+      plural: gitopswpservices
     chartURL: https://github.com/cloud-ark/k8s-workshop/blob/master/wordpress-deployment-chart/wordpress-chart-0.0.3.tgz?raw=true
     chartName: wordpress-chart
   respolicy:
@@ -18,7 +18,7 @@ spec:
       name: gitops-wordpress-service-policy
     spec:
       resource:
-        kind: GitopsWordpressService
+        kind: GitopsWPService
         group: platformapi.kubeplus
         version: v1alpha1
       policy:
@@ -42,7 +42,7 @@ spec:
       name: gitops-wordpress-service-monitor
     spec:
       resource:
-        kind: GitopsWordpressService
+        kind: GitopsWPService
         group: platformapi.kubeplus
         version: v1alpha1
       monitorRelationships: all

--- a/examples/multitenancy/application-hosting/wordpress-argocd/provider/wordpress-service-composition.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/provider/wordpress-service-composition.yaml
@@ -1,0 +1,48 @@
+apiVersion: workflows.kubeplus/v1alpha1
+kind: ResourceComposition
+metadata:
+  name: gitops-wordpress-service-composition
+spec:
+  newResource:
+    resource:
+      kind: GitopsWordpressService
+      group: platformapi.kubeplus
+      version: v1alpha1
+      plural: gitopswordpressservices
+    chartURL: https://github.com/cloud-ark/k8s-workshop/blob/master/wordpress-deployment-chart/wordpress-chart-0.0.3.tgz?raw=true
+    chartName: wordpress-chart
+  respolicy:
+    apiVersion: workflows.kubeplus/v1alpha1
+    kind: ResourcePolicy
+    metadata:
+      name: gitops-wordpress-service-policy
+    spec:
+      resource:
+        kind: GitopsWordpressService
+        group: platformapi.kubeplus
+        version: v1alpha1
+      policy:
+        podconfig:
+          limits:
+            cpu: 200m
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 1Gi
+          nodeSelector: values.nodeName
+        quota:
+          requests.cpu: 100m
+          requests.memory: 1Gi
+          limits.cpu: 200m
+          limits.memory: 2Gi
+  resmonitor:
+    apiVersion: workflows.kubeplus/v1alpha1
+    kind: ResourceMonitor
+    metadata:
+      name: gitops-wordpress-service-monitor
+    spec:
+      resource:
+        kind: GitopsWordpressService
+        group: platformapi.kubeplus
+        version: v1alpha1
+      monitorRelationships: all

--- a/examples/multitenancy/application-hosting/wordpress-argocd/provider/wordpress-service-composition.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/provider/wordpress-service-composition.yaml
@@ -1,0 +1,48 @@
+apiVersion: workflows.kubeplus/v1alpha1
+kind: ResourceComposition
+metadata:
+  name: gitops-wordpress-service-composition
+spec:
+  newResource:
+    resource:
+      kind: GitopsWPService
+      group: platformapi.kubeplus
+      version: v1alpha1
+      plural: gitopswpservices
+    chartURL: https://github.com/cloud-ark/k8s-workshop/blob/master/wordpress-deployment-chart/wordpress-chart-0.0.3.tgz?raw=true
+    chartName: wordpress-chart
+  respolicy:
+    apiVersion: workflows.kubeplus/v1alpha1
+    kind: ResourcePolicy
+    metadata:
+      name: gitops-wordpress-service-policy
+    spec:
+      resource:
+        kind: GitopsWPService
+        group: platformapi.kubeplus
+        version: v1alpha1
+      policy:
+        podconfig:
+          limits:
+            cpu: 200m
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 1Gi
+          nodeSelector: values.nodeName
+        quota:
+          requests.cpu: 100m
+          requests.memory: 1Gi
+          limits.cpu: 200m
+          limits.memory: 2Gi
+  resmonitor:
+    apiVersion: workflows.kubeplus/v1alpha1
+    kind: ResourceMonitor
+    metadata:
+      name: gitops-wordpress-service-monitor
+    spec:
+      resource:
+        kind: GitopsWPService
+        group: platformapi.kubeplus
+        version: v1alpha1
+      monitorRelationships: all

--- a/examples/multitenancy/application-hosting/wordpress-argocd/steps.txt
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/steps.txt
@@ -1,0 +1,47 @@
+WordPress via ArgoCD + KubePlus
+-------------------------------
+This example scaffolds a GitOps flow where:
+- ArgoCD syncs KubePlus manifests from Git.
+- KubePlus creates the custom API and provisions isolated WordPress tenants.
+
+Folder layout
+-------------
+- `provider/`: KubePlus `ResourceComposition` that defines the custom API.
+- `tenants/`: Tenant instances of the custom API.
+- `argocd-provider-app.yaml`: ArgoCD `Application` for the provider layer.
+- `argocd-tenants-app.yaml`: ArgoCD `Application` for the tenant layer.
+
+Suggested flow
+--------------
+1. Install KubePlus in your target namespace, for example `default`.
+
+2. Install ArgoCD in the cluster and confirm the `argocd` namespace exists.
+
+3. Update these placeholders before applying the ArgoCD manifests:
+   - `REPLACE_WITH_GIT_REPO_URL`
+   - `REPLACE_WITH_GIT_TARGET_REVISION`
+   - `REPLACE_WITH_KUBEPLUS_NAMESPACE`
+
+4. Apply the provider ArgoCD application first:
+   $ kubectl apply -f argocd-provider-app.yaml -n argocd
+
+5. Wait for the custom API to be registered:
+   $ until kubectl get crds | grep gitopswordpressservices.platformapi.kubeplus; do echo "Waiting for CRD..."; sleep 2; done
+
+6. Apply the tenant ArgoCD application:
+   $ kubectl apply -f argocd-tenants-app.yaml -n argocd
+
+7. Verify that KubePlus created the tenant namespaces and resources:
+   $ kubectl get gitopswordpressservices -n <kubeplus-namespace>
+   $ kubectl get ns
+   $ kubectl get pods -n wp-tenant1
+
+8. Verify KubePlus resource tracking still works:
+   $ kubectl appresources GitopsWordpressService wp-tenant1 -k kubeplus-saas-provider.json
+   $ kubectl metrics GitopsWordpressService wp-tenant1 -k kubeplus-saas-provider.json
+
+Next iteration ideas
+--------------------
+- Add a Git change that creates `tenant2`.
+- Expose one or two WordPress chart values through the custom API and verify ArgoCD-driven updates.
+- Add an app-of-apps manifest if you want ArgoCD to own both `Application` resources.

--- a/examples/multitenancy/application-hosting/wordpress-argocd/steps.txt
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/steps.txt
@@ -1,0 +1,131 @@
+WordPress via ArgoCD + KubePlus
+-------------------------------
+This example scaffolds a GitOps flow where:
+- ArgoCD syncs the provider-side `ResourceComposition` from this
+  `kubeplus-examples` repo.
+- ArgoCD syncs tenant instances of that custom API from this same repo using a
+  different subpath.
+- KubePlus provisions isolated WordPress tenants from those tenant objects.
+
+Folder layout
+-------------
+- `provider/`: KubePlus `ResourceComposition` that defines the custom API.
+- `tenants/`: Tenant instances of the custom API.
+- `argocd-provider-project.yaml`: ArgoCD `AppProject` that syncs as `kubeplus-saas-provider`.
+- `argocd-tenants-project.yaml`: ArgoCD `AppProject` that syncs as `kubeplus-saas-consumer`.
+- `argocd-provider-app.yaml`: ArgoCD `Application` for the provider layer.
+- `argocd-tenants-app.yaml`: ArgoCD `Application` for the tenant layer.
+
+Suggested flow
+--------------
+1. Install KubePlus in your target namespace, for example `default`.
+
+2. Install ArgoCD:
+
+   kubectl get namespace argocd >/dev/null 2>&1 || kubectl create namespace argocd
+   kubectl apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+   kubectl rollout status deployment/argocd-server -n argocd --timeout=180s
+   kubectl get pods -n argocd
+
+3. Access the ArgoCD UI:
+
+   kubectl port-forward svc/argocd-server -n argocd 8080:443
+   kubectl get secret argocd-initial-admin-secret -n argocd -o jsonpath='{.data.password}' | base64 -d; echo
+
+   Open:
+
+   https://localhost:8080
+
+   Username:
+
+   admin
+
+4. Enable ArgoCD sync impersonation:
+
+   kubectl patch cm argocd-cm -n argocd --type merge -p '{"data":{"application.sync.impersonation.enabled":"true"}}'
+   kubectl rollout restart statefulset argocd-application-controller -n argocd
+
+5. Apply the ArgoCD projects:
+
+   kubectl apply -f <wordpress-argocd-example-dir>/argocd-provider-project.yaml -n argocd
+   kubectl apply -f <wordpress-argocd-example-dir>/argocd-tenants-project.yaml -n argocd
+
+6. Clone or fork the `kubeplus-examples` repo:
+
+   git clone https://github.com/cloud-ark/kubeplus-examples.git
+
+7. Apply the provider ArgoCD application:
+
+   kubectl apply -f <wordpress-argocd-example-dir>/argocd-provider-app.yaml -n argocd
+
+8. Wait for the custom API to exist:
+
+   until kubectl get crds | grep gitopswpservices.platformapi.kubeplus; do echo "Waiting for CRD..."; sleep 2; done
+
+9. Apply the tenant ArgoCD application:
+
+   kubectl apply -f <wordpress-argocd-example-dir>/argocd-tenants-app.yaml -n argocd
+
+10. Verify that KubePlus created the tenant namespaces and resources:
+
+   kubectl get application kubeplus-wordpress-provider -n argocd
+   kubectl get application kubeplus-wordpress-tenants -n argocd
+   kubectl get gitopswpservices -n default
+   kubectl get ns | grep wp-
+   kubectl get pods -n wp-tenant1
+
+11. Test provider-side sync by modifying the provider `ResourceComposition` in
+    `kubeplus-examples` and pushing:
+
+   cd <kubeplus-examples-repo>
+
+   Edit:
+
+   multitenancy/application-hosting/wordpress-argocd/provider/wordpress-service-composition.yaml
+
+   Add this annotation under `metadata`:
+
+   annotations:
+     demo.kubeplus.dev/provider-sync-test: "2026-05-04-a"
+
+   git add multitenancy/application-hosting/wordpress-argocd/provider/wordpress-service-composition.yaml
+   git commit -m "Test wordpress provider Argo CD sync"
+   git push
+
+   The hard refresh tells Argo CD to invalidate its cached Git and manifest
+   state so the provider application immediately reconciles the pushed
+   `ResourceComposition` change during this test.
+
+   kubectl annotate application kubeplus-wordpress-provider -n argocd argocd.argoproj.io/refresh=hard --overwrite
+   kubectl get application kubeplus-wordpress-provider -n argocd
+   kubectl get resourcecomposition gitops-wordpress-service-composition -n default -o yaml
+
+12. Test tenant-side GitOps changes by editing the tenant manifests in
+    `kubeplus-examples` and pushing:
+
+   cd <kubeplus-examples-repo>
+   git add multitenancy/application-hosting/wordpress-argocd/tenants/tenant1.yaml multitenancy/application-hosting/wordpress-argocd/tenants/tenant2.yaml multitenancy/application-hosting/wordpress-argocd/tenants/kustomization.yaml
+   git commit -m "Update wordpress tenants"
+   git push
+
+13. Watch ArgoCD reconcile:
+
+   kubectl get application kubeplus-wordpress-provider -n argocd -w
+   kubectl get application kubeplus-wordpress-tenants -n argocd -w
+   kubectl get gitopswpservices -n default
+   kubectl get pods -n wp-tenant1
+   kubectl get pods -n wp-tenant2
+
+Notes
+-----
+- KubePlus enforces that only a Provider can create a `ResourceComposition`, so the provider ArgoCD app must sync as `kubeplus-saas-provider`.
+- Tenant apps can sync as `kubeplus-saas-consumer`, which can create `GitopsWPService` instances but cannot create `ResourceComposition`.
+- Both ArgoCD applications point at `cloud-ark/kubeplus-examples`, but
+  use different subpaths under `multitenancy/application-hosting/wordpress-argocd/`.
+- The shorter custom kind `GitopsWPService` avoids KubePlus's Helm release-name length limit and allows tenant names like `wp-tenant1`.
+
+Next iteration ideas
+--------------------
+- Add a Git change that creates `tenant2`.
+- Expose one or two WordPress chart values through the custom API and verify ArgoCD-driven updates.
+- Add a provider-side ArgoCD flow only after configuring ArgoCD to authenticate as a KubePlus Provider.

--- a/examples/multitenancy/application-hosting/wordpress-argocd/tenants/kustomization.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/tenants/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tenant1.yaml
+  - tenant2.yaml

--- a/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant1.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant1.yaml
@@ -1,0 +1,6 @@
+apiVersion: platformapi.kubeplus/v1alpha1
+kind: GitopsWPService
+metadata:
+  name: wp-tenant1
+spec:
+  resourceName: wp-for-tenant1

--- a/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant1.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant1.yaml
@@ -1,5 +1,5 @@
 apiVersion: platformapi.kubeplus/v1alpha1
-kind: GitopsWordpressService
+kind: GitopsWPService
 metadata:
   name: wp-tenant1
 spec:

--- a/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant1.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant1.yaml
@@ -1,0 +1,6 @@
+apiVersion: platformapi.kubeplus/v1alpha1
+kind: GitopsWordpressService
+metadata:
+  name: wp-tenant1
+spec:
+  resourceName: wp-for-tenant1

--- a/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant2.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant2.yaml
@@ -1,0 +1,6 @@
+apiVersion: platformapi.kubeplus/v1alpha1
+kind: GitopsWPService
+metadata:
+  name: wp-tenant2
+spec:
+  resourceName: wp-for-tenant2

--- a/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant2.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant2.yaml
@@ -1,5 +1,5 @@
 apiVersion: platformapi.kubeplus/v1alpha1
-kind: GitopsWordpressService
+kind: GitopsWPService
 metadata:
   name: wp-tenant2
 spec:

--- a/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant2.yaml
+++ b/examples/multitenancy/application-hosting/wordpress-argocd/tenants/tenant2.yaml
@@ -1,0 +1,6 @@
+apiVersion: platformapi.kubeplus/v1alpha1
+kind: GitopsWordpressService
+metadata:
+  name: wp-tenant2
+spec:
+  resourceName: wp-for-tenant2

--- a/examples/multitenancy/hello-world/argocd-consumer-app.yaml
+++ b/examples/multitenancy/hello-world/argocd-consumer-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kubeplus-hello-world-consumer
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/PatrickBladeeman/hello-world-argocd-consumer
+    targetRevision: main
+    path: tenants
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/examples/multitenancy/hello-world/steps.txt
+++ b/examples/multitenancy/hello-world/steps.txt
@@ -128,3 +128,31 @@ Clean up:
   - kubectl delete -f hello-world-service-composition.yaml --kubeconfig=provider.conf
   - kubectl get crds
     - should see that helloworldservices.platformapi.kubeplus crd is gone
+
+
+Argo CD consumer-only flow:
+---------------------------
+This is the minimum GitOps flow for the consumer side only. The provider still
+creates the HelloWorldService API manually using hello-world-service-composition.yaml.
+This flow does not use Argo CD impersonation for the consumer.
+
+1. Create the HelloWorldService API as provider:
+   - kubectl create -f hello-world-service-composition.yaml --kubeconfig=provider.conf
+   - until kubectl get crds --kubeconfig=provider.conf | grep helloworldservices.platformapi.kubeplus ; do echo "Waiting for HelloWorldService CRD..."; sleep 1; done
+
+2. Apply the consumer Application:
+   - kubectl apply -f argocd-consumer-app.yaml -n argocd
+
+3. Verify the initial sync:
+   - kubectl get applications -n argocd
+   - kubectl get helloworldservices.platformapi.kubeplus -n default
+   - kubectl get pods -n hs1
+
+4. Test GitOps update of replicas:
+   - edit hs1.yaml in the hello-world-argocd-consumer repo and change replicas from 1 to 2
+   - commit and push the change
+   - wait for Argo CD to sync
+   - kubectl get pods -n hs1
+
+5. Verify the updated custom resource:
+   - kubectl get helloworldservices.platformapi.kubeplus hs1 -n default -o yaml

--- a/examples/multitenancy/hello-world/steps.txt
+++ b/examples/multitenancy/hello-world/steps.txt
@@ -128,3 +128,12 @@ Clean up:
   - kubectl delete -f hello-world-service-composition.yaml --kubeconfig=provider.conf
   - kubectl get crds
     - should see that helloworldservices.platformapi.kubeplus crd is gone
+
+
+Argo CD GitOps flow:
+--------------------
+The Argo CD examples are maintained in the kubeplus-examples repository:
+https://github.com/cloud-ark/kubeplus-examples
+
+See:
+multitenancy/application-hosting/hello-world-argocd

--- a/platform-operator/pkg/apis/workflowcontroller/v1alpha1/types.go
+++ b/platform-operator/pkg/apis/workflowcontroller/v1alpha1/types.go
@@ -117,6 +117,7 @@ type ResourcePolicySpec struct {
 
 type Pol struct {
 	PolicyResources PolicyResources `json:"podconfig"`
+	Quota Quota `json:"quota"`
 }
 
 type PolicyResources struct {
@@ -125,6 +126,13 @@ type PolicyResources struct {
 	Limits Limits `json:"limits"`
 	Requests Requests `json:"requests"`
 	NodeSelector string `json:"nodeSelector"`
+}
+
+type Quota struct {
+	CPURequests string `json:"requests.cpu"`
+	MemoryRequests string `json:"requests.memory"`
+	CPULimits string `json:"limits.cpu"`
+	MemoryLimits string `json:"limits.memory"`
 }
 
 type Limits struct {
@@ -228,4 +236,3 @@ type ResourceEventSpec struct {
 type Cond struct {
 	Condition string `json:"condition"`
 }
-


### PR DESCRIPTION
This PR adds Argo CD GitOps examples for KubePlus while keeping the runtime sync target lightweight.

The same example content is mirrored in the core `kubeplus` repo for review and discoverability, and the Argo CD `Application` manifests point at the lightweight examples repo:

https://github.com/cloud-ark/kubeplus-examples

Changes in this PR:

- Adds `examples/multitenancy/application-hosting/hello-world-argocd`, matching the corresponding example in `cloud-ark/kubeplus-examples`.
- Adds `examples/multitenancy/application-hosting/wordpress-argocd`, matching the corresponding example in `cloud-ark/kubeplus-examples`.
- Documents where to find the Argo CD GitOps flow from the existing hello-world walkthrough.
- Adds `quota` fields to the `ResourcePolicy` Go type so ResourceComposition examples that define quota policy can round-trip cleanly through the KubePlus API.

The key design is that users can read/copy the examples from this repo, but Argo CD should sync from `cloud-ark/kubeplus-examples` because it is much smaller than the full `kubeplus` repository.
