### PR TITLE
Fix WordPress example documentation

### DIFF
--- a/examples/multitenancy/application-hosting/wordpress/steps.txt
+++ b/examples/multitenancy/application-hosting/wordpress/steps.txt
@@ -24,9 +24,9 @@ $ kubectl kubeplus commands
    - Extract provider kubeconfig:
      $ KUBEPLUS_NS=default
      $ apiserver=`kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'`
-     $ python3 provider-kubeconfig.py create  -s $apiserver create $KUBEPLUS_NS
-     $ cp kubeplus-saas-provider.json examples/multitenancy/wordpress/.
-     $ cd examples/multitenancy/wordpress/
+     $ python3 provider-kubeconfig.py -s $apiserver create $KUBEPLUS_NS
+     $ cp kubeplus-saas-provider.json examples/multitenancy/application-hosting/wordpress/.
+     $ cd examples/multitenancy/application-hosting/wordpress/
 
 4. Install KubePlus Operator:
    $ helm install kubeplus "https://github.com/cloud-ark/operatorcharts/blob/master/kubeplus-chart-4.2.0.tgz?raw=true" -n $KUBEPLUS_NS --kubeconfig=kubeplus-saas-provider.json


### PR DESCRIPTION
This PR fixes two issues in the WordPress example documentation:

1. Corrects the provider-kubeconfig.py command syntax.
2. Updates the WordPress example path to the current repository location.

These issues were discovered while retesting #1442.