### PR TITLE
Restrict consumer permissions

### DIFF
--- a/provider-kubeconfig.py
+++ b/provider-kubeconfig.py
@@ -32,7 +32,9 @@ def create_role_rolebinding(contents, name, kubeconfig):
     file_path = os.path.join(os.getcwd(), name)
     with open(file_path, "w", encoding="utf-8") as fp:
         fp.write(yaml.dump(contents))
-    run_command(" kubectl apply -f " + file_path + kubeconfig)
+    _, err, rc = run_command_with_code(" kubectl apply -f " + file_path + kubeconfig)
+    if rc != 0:
+        raise RuntimeError(f"Failed to apply RBAC manifest {file_path!r}: {err.strip()}")
 
 
 def run_command(cmd):
@@ -533,7 +535,7 @@ class KubeconfigGenerator(object):
                 return ruleList
 
         def _apply_consumer_rbac(self, sa, namespace, kubeconfig):
-                """Apply ClusterRole and ClusterRoleBinding for consumer (read + apps + impersonate + portforward)."""
+                """Apply ClusterRole and RoleBinding for consumer (read + apps + impersonate + portforward)."""
                 rule_list = self._build_consumer_rules()
                 all_resources = self._all_resources_from_rules(rule_list)
                 role = {
@@ -546,7 +548,7 @@ class KubeconfigGenerator(object):
 
                 role_binding = {
                     "apiVersion": "rbac.authorization.k8s.io/v1",
-                    "kind": "ClusterRoleBinding",
+                    "kind": "RoleBinding",
                     "metadata": {"name": sa, "namespace": namespace},
                     "subjects": [{"kind": "ServiceAccount", "name": sa, "namespace": namespace, "apiGroup": ""}],
                     "roleRef": {"kind": "ClusterRole", "name": sa, "apiGroup": "rbac.authorization.k8s.io"},
@@ -591,8 +593,8 @@ class KubeconfigGenerator(object):
                     + " --from-file=" + cfg_map_filename + kubeconfig
                 )
 
-        def _update_rbac(self, permissionfile, sa, namespace, kubeconfig):
-                """Add permissions from JSON/YAML file to provider (update command)."""
+        def _update_rbac(self, permissionfile, sa, namespace, kubeconfig, entity):
+                """Add permissions from JSON/YAML file using requested binding scope (update command)."""
                 perms = self._load_permission_data(permissionfile)
                 rule_list, new_resources = self._parse_permission_rules(perms)
 
@@ -606,7 +608,7 @@ class KubeconfigGenerator(object):
 
                 role_binding = {
                     "apiVersion": "rbac.authorization.k8s.io/v1",
-                    "kind": "ClusterRoleBinding",
+                    "kind": "ClusterRoleBinding" if entity == "provider" else "RoleBinding",
                     "metadata": {"name": sa + "-update", "namespace": namespace},
                     "subjects": [{"kind": "ServiceAccount", "name": sa, "namespace": namespace, "apiGroup": ""}],
                     "roleRef": {"kind": "ClusterRole", "name": sa + "-update", "apiGroup": "rbac.authorization.k8s.io"},
@@ -760,7 +762,7 @@ class KubeconfigGenerator(object):
                                 remaining_rules.append(updated_rule)
                 return existing_rules, remaining_rules
 
-        def _revoke_rbac(self, permissionfile, sa, namespace, kubeconfig):
+        def _revoke_rbac(self, permissionfile, sa, namespace, kubeconfig, entity):
                 """Revoke permissions from permission file.
 
                 Flow:
@@ -840,7 +842,10 @@ class KubeconfigGenerator(object):
                         self._kubectl_or_raise("apply -f " + role_filename, kubeconfig)
                 else:
                         self._kubectl_or_raise("delete clusterrole " + role_name, kubeconfig)
-                        self._kubectl_or_raise("delete clusterrolebinding " + rolebinding_name, kubeconfig)
+                        if entity == "consumer":
+                            self._kubectl_or_raise("delete rolebinding " + rolebinding_name + " -n " + namespace, kubeconfig)
+                        else:
+                            self._kubectl_or_raise("delete clusterrolebinding " + rolebinding_name, kubeconfig)
 
                 # Keep configmap simple and authoritative: rebuild from current roles.
                 self._rebuild_perm_configmap_from_roles(sa, namespace, kubeconfig)
@@ -1013,6 +1018,7 @@ if __name__ == "__main__":
         sa = 'kubeplus-saas-provider'
         if pargs.consumer:
             sa = pargs.consumer
+        entity = "provider" if sa == "kubeplus-saas-provider" else "consumer"
 
         filename = pargs.filename or sa
         if not filename.endswith(".json"):
@@ -1032,25 +1038,20 @@ if __name__ == "__main__":
                 run_command(cmd)
 
                 # 1. Generate Provider kubeconfig
-                if sa == "kubeplus-saas-provider":
-                    kubeconfigGenerator._generate_kubeconfig(sa, namespace, filename, api_server_ip=api_s_ip, kubeconfig=kubeconfigString, cluster_name=cluster_name)
-                    kubeconfigGenerator._apply_rbac(sa, namespace, entity='provider', kubeconfig=kubeconfigString)
-                    print("Provider kubeconfig created: " + filename)
-                else:
-                    kubeconfigGenerator._generate_kubeconfig(sa, namespace, filename, api_server_ip=api_s_ip, kubeconfig=kubeconfigString, cluster_name=cluster_name)
-                    kubeconfigGenerator._apply_rbac(sa, namespace, entity='consumer', kubeconfig=kubeconfigString)
-                    print("Consumer kubeconfig created: " + filename)
+                kubeconfigGenerator._generate_kubeconfig(sa, namespace, filename, api_server_ip=api_s_ip, kubeconfig=kubeconfigString, cluster_name=cluster_name)
+                kubeconfigGenerator._apply_rbac(sa, namespace, entity=entity, kubeconfig=kubeconfigString)
+                print(entity.capitalize() + " kubeconfig created: " + filename)
 
         if action == "extract":
                 kubeconfigGenerator._extract_kubeconfig(sa, namespace, filename, serverip=api_s_ip, kubecfg=kubeconfigString)
                 print("Provider kubeconfig created: " + filename)
 
         if action == "update":
-                kubeconfigGenerator._update_rbac(permission_file, sa, namespace, kubeconfigString)
+                kubeconfigGenerator._update_rbac(permission_file, sa, namespace, kubeconfigString, entity=entity)
                 print("kubeconfig permissions updated: " + filename)
 
         if action == "revoke":
-                if kubeconfigGenerator._revoke_rbac(permission_file, sa, namespace, kubeconfigString):
+                if kubeconfigGenerator._revoke_rbac(permission_file, sa, namespace, kubeconfigString, entity=entity):
                         print("kubeconfig permissions revoked: " + filename)
 
 
@@ -1058,9 +1059,22 @@ if __name__ == "__main__":
                 run_command("kubectl delete sa " + sa + " -n " + namespace + kubeconfigString)
                 run_command("kubectl delete configmap " + sa + " -n " + namespace + kubeconfigString)
                 run_command("kubectl delete clusterrole " + sa + kubeconfigString)
-                run_command("kubectl delete clusterrolebinding " + sa + kubeconfigString)
+                if entity == "consumer":
+                    # consumer binding
+                    run_command("kubectl delete rolebinding " + sa + " -n " + namespace + " --ignore-not-found" + kubeconfigString)
+                    # legacy consumer binding
+                    run_command("kubectl delete clusterrolebinding " + sa + " --ignore-not-found" + kubeconfigString) # backwards-compatible
+                else:
+                    # provider binding
+                    run_command("kubectl delete clusterrolebinding " + sa + kubeconfigString)
                 run_command("kubectl delete clusterrole " + sa + "-update" + kubeconfigString)
-                run_command("kubectl delete clusterrolebinding " + sa + "-update" + kubeconfigString)
+                if entity == "consumer":
+                    # consumer binding
+                    run_command( "kubectl delete rolebinding " + sa + "-update" + " -n " + namespace + " --ignore-not-found" + kubeconfigString)
+                    # legacy consumer binding
+                    run_command( "kubectl delete clusterrolebinding " + sa + "-update" + " --ignore-not-found" + kubeconfigString)
+                else:
+                    run_command( "kubectl delete clusterrolebinding " + sa + "-update" + kubeconfigString)
                 run_command("kubectl delete configmap " + sa + "-perms -n " + namespace + kubeconfigString)
                 cwd = os.getcwd()
                 for f in [

--- a/provider-kubeconfig.py
+++ b/provider-kubeconfig.py
@@ -32,9 +32,7 @@ def create_role_rolebinding(contents, name, kubeconfig):
     file_path = os.path.join(os.getcwd(), name)
     with open(file_path, "w", encoding="utf-8") as fp:
         fp.write(yaml.dump(contents))
-    _, err, rc = run_command_with_code(" kubectl apply -f " + file_path + kubeconfig)
-    if rc != 0:
-        raise RuntimeError(f"Failed to apply RBAC manifest {file_path!r}: {err.strip()}")
+    run_command(" kubectl apply -f " + file_path + kubeconfig)
 
 
 def run_command(cmd):
@@ -1059,23 +1057,20 @@ if __name__ == "__main__":
                 run_command("kubectl delete sa " + sa + " -n " + namespace + kubeconfigString)
                 run_command("kubectl delete configmap " + sa + " -n " + namespace + kubeconfigString)
                 run_command("kubectl delete clusterrole " + sa + kubeconfigString)
-                if entity == "consumer":
-                    # consumer binding
-                    run_command("kubectl delete rolebinding " + sa + " -n " + namespace + " --ignore-not-found" + kubeconfigString)
-                    # legacy consumer binding
-                    run_command("kubectl delete clusterrolebinding " + sa + " --ignore-not-found" + kubeconfigString) # backwards-compatible
-                else:
-                    # provider binding
-                    run_command("kubectl delete clusterrolebinding " + sa + kubeconfigString)
                 run_command("kubectl delete clusterrole " + sa + "-update" + kubeconfigString)
                 if entity == "consumer":
-                    # consumer binding
+                    # consumer bindings
+                    run_command("kubectl delete rolebinding " + sa + " -n " + namespace + " --ignore-not-found" + kubeconfigString)
                     run_command( "kubectl delete rolebinding " + sa + "-update" + " -n " + namespace + " --ignore-not-found" + kubeconfigString)
-                    # legacy consumer binding
+                    # legacy consumer bindings
+                    run_command("kubectl delete clusterrolebinding " + sa + " --ignore-not-found" + kubeconfigString) # backwards-compatible
                     run_command( "kubectl delete clusterrolebinding " + sa + "-update" + " --ignore-not-found" + kubeconfigString)
                 else:
+                    # provider bindings
+                    run_command("kubectl delete clusterrolebinding " + sa + kubeconfigString)
                     run_command( "kubectl delete clusterrolebinding " + sa + "-update" + kubeconfigString)
                 run_command("kubectl delete configmap " + sa + "-perms -n " + namespace + kubeconfigString)
+
                 cwd = os.getcwd()
                 for f in [
                     sa + "-secret.yaml", filename, sa + "-role.yaml", sa + "-update-role.yaml",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -104,6 +104,55 @@ class TestKubePlus(unittest.TestCase):
         cmd = "kubectl delete -f ../examples/multitenancy/hello-world/hello-world-service-composition-localchart.yaml --kubeconfig=%s" % provider
         TestKubePlus.run_command(cmd)
 
+    def test_consumer_cannot_create_deployment_in_another_namespace(self):
+        """Consumers must not create deployments outside their own namespace."""
+        out, err = TestKubePlus.run_command("kubectl get ns default")
+        if "default" not in out or "unable to connect" in err.lower():
+            self.skipTest("No cluster reachable for consumer RBAC test.")
+
+        out, err = TestKubePlus.run_command("kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'")
+        api_server = out.strip().strip("'")
+        if api_server == "":
+            self.skipTest("Could not determine current cluster API server.")
+
+        suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
+        ns1, ns2 = f"kp-ns1-{suffix}", f"kp-ns2-{suffix}"
+        consumer1, consumer2 = f"kp-cons1-{suffix}", f"kp-cons2-{suffix}"
+        script = pathlib.Path(__file__).resolve().parents[1] / "provider-kubeconfig.py"
+        consumer2_kubeconfig = pathlib.Path.cwd() / (consumer2 + ".json")
+
+        def skip_on_connection_error(err):
+            lowered = err.lower()
+            if "unable to connect to the server" in lowered or "i/o timeout" in lowered:
+                self.skipTest("Skipping authz assertion due to transient API connectivity issue: " + err.strip())
+
+        try:
+            for namespace, consumer in ((ns1, consumer1), (ns2, consumer2)):
+                cmd = f"{sys.executable} {script} create {namespace} -c {consumer} -s {api_server}"
+                out, err = TestKubePlus.run_command(cmd)
+                skip_on_connection_error(err)
+                self.assertTrue(
+                    pathlib.Path(consumer + ".json").exists(),
+                    "Consumer kubeconfig should be created for %s; got out=%r err=%r"
+                    % (consumer, out, err),
+                )
+
+            cmd = f"kubectl auth can-i create deployments.apps -n {ns2} --kubeconfig={consumer2_kubeconfig}"
+            out, err = TestKubePlus.run_command(cmd)
+            skip_on_connection_error(err)
+            self.assertEqual(out.strip(), "yes")
+
+            cmd = f"kubectl auth can-i create deployments.apps -n {ns1} --kubeconfig={consumer2_kubeconfig}"
+            out, err = TestKubePlus.run_command(cmd)
+            skip_on_connection_error(err)
+            self.assertEqual(out.strip(), "no")
+        finally:
+            for namespace, consumer in ((ns1, consumer1), (ns2, consumer2)):
+                TestKubePlus.run_command(f"{sys.executable} {script} delete {namespace} -c {consumer}")
+                TestKubePlus.run_command(f"kubectl delete namespace {namespace} --ignore-not-found --wait=false")
+                for file in pathlib.Path.cwd().glob(consumer + "*"):
+                    file.unlink(missing_ok=True)
+
     def test_create_res_comp_for_chart_with_ns(self):
         if not TestKubePlus._is_kubeplus_running():
             print("KubePlus is not running. Deploy KubePlus and then run tests")


### PR DESCRIPTION
Addresses #1472

Hello! This is my first contribution to the project - I’m happy to make adjustments based on review and feedback.

## Problem

Consumer permissions were granted through a `ClusterRoleBinding`, which made otherwise namespaced permissions available across the cluster.

For example, a consumer associated with `namespace1` could create a Deployment in `namespace2`.

## Changes

This PR changes consumer RBAC bindings from `ClusterRoleBinding` to namespaced `RoleBinding` objects. The `RoleBinding` continues to reference the existing `ClusterRole`, but limits applicable permissions to the consumer’s namespace.

Providers continue to use `ClusterRoleBinding` objects because they require cluster-scoped access.

The update, revoke, and delete paths previously shared binding-management logic between providers and consumers. I added entity-specific handling so that:

* Consumers use `RoleBinding`.
* Providers use `ClusterRoleBinding`.
* Consumer deletion also cleans up legacy `ClusterRoleBinding` objects.

I also added a regression test that reproduces the original issue by creating two namespaced consumers and verifying that one consumer cannot create a Deployment in the other consumer’s namespace. The test fails with the previous implementation and passes with this change.

## Migration considerations

This PR does not automatically migrate existing consumer `ClusterRoleBinding` objects.

The change applies to newly created consumer bindings and permissions added through the update command. Legacy consumer bindings are removed by the delete command, but existing bindings are not migrated during update or revoke operations.

I would appreciate guidance on whether this PR should also include a migration path for existing consumers, or whether migration should be handled separately.

Thanks!
