### PR TITLE
Add requests dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyyaml
+requests


### PR DESCRIPTION
Add the missing `requests` dependency to the top level `requirements.txt`.

Fixes #1466