### PR TITLE
Fix resource name mismatch in application update test

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -60,8 +60,9 @@ class TestKubePlus(unittest.TestCase):
         return False
 
     @classmethod
-    def _process_template(cls, file):
-        name = "kp-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
+    def _process_template(cls, file, name=None):
+        if name is None:
+            name = "kp-" + "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
         with open(file) as file_in, NamedTemporaryFile(mode='w+', suffix='.yaml', delete=False) as out:
             template = Template(file_in.read())
             out.write(template.render(name=name))
@@ -262,7 +263,7 @@ class TestKubePlus(unittest.TestCase):
             sys.exit(0)
 
         hs1_name, hs1_file = TestKubePlus._process_template("template-manifests/hello-world-hs1.yaml")
-        _, hs_replicas_file = TestKubePlus._process_template("template-manifests/hello-world-hs1-replicas-2.yaml")
+        _, hs_replicas_file = TestKubePlus._process_template("template-manifests/hello-world-hs1-replicas-2.yaml", name=hs1_name)
 
         kubeplus_home = os.getenv("KUBEPLUS_HOME")
         # print("KubePlus home:" + kubeplus_home)


### PR DESCRIPTION
## Problem

`test_application_update` generated different resource names for the initial and replica update manifests

As a result, `kubectl replace` attempts to update a HelloWorldService that was never created and fails with a `NotFound` error.

## Fix

Allow `_process_template()` to accept an optional resource name and reuse the original `hs1_name` when generating the replicas update manifest.

This ensures both manifests refer to the same HelloWorldService resource.