### PR TITLE
Preserve wildcard grant rules during RBAC revoke

### DIFF
--- a/provider-kubeconfig.py
+++ b/provider-kubeconfig.py
@@ -115,6 +115,14 @@ class KubeconfigGenerator(object):
                         return None
                 raise RuntimeError(f"Failed to fetch clusterrole {name!r}: {err.strip()}")
 
+        def _fetch_api_resources(self, api_group, kubeconfig):
+                """Return resource names available for the given API group."""
+                out, err, rc = run_command_with_code("kubectl api-resources " + "--api-group=" + api_group + " -o json" + kubeconfig)
+                if rc != 0:
+                        raise RuntimeError(f"Failed to fetch API resources for group {api_group!r}: {err.strip()}")
+                data = json.loads(out)
+                return sorted(resource["name"] for resource in data.get("resources", []))
+
         def _rules_changed(self, existing_rules, remaining_rules):
                 return self._normalize_rule_list(existing_rules) != self._normalize_rule_list(remaining_rules)
 
@@ -624,10 +632,17 @@ class KubeconfigGenerator(object):
                 """
                 existing_list = list(existing_verbs)
                 revoke_set = set(revoke_verbs)
-                if "*" in existing_list and revoke_set:
-                        return None
                 if "*" in revoke_set:
                         return None
+                if "*" in existing_list:
+                        existing_list = ["get",
+                                         "list",
+                                         "watch",
+                                         "create",
+                                         "update",
+                                         "patch",
+                                         "delete",
+                                         "deletecollection"]
                 remaining = [v for v in existing_list if v not in revoke_set]
                 return remaining or None
 
@@ -647,19 +662,14 @@ class KubeconfigGenerator(object):
                 - For URL rules, compare only nonResourceURLs.
                 - For normal resource rules, compare apiGroups + resources.
                 - A '*' in the revoke rule matches all values.
-                - Existing wildcard grant rules are preserved unless the revoke rule also uses '*'.
                 """
                 def _overlaps(revoke_values, existing_values):
                         if not revoke_values or not existing_values:
                                 return False
 
-                        # A wildcard in the revoke rule matches all existing values.
-                        if "*" in revoke_values:
+                        # A wildcard in either rule overlaps with the other rule.
+                        if "*" in revoke_values or "*" in existing_values:
                                 return True
-
-                        # Preserve wildcard grant rules when revoking a specific permission
-                        if "*" in existing_values:
-                                return False
 
                         return bool(set(revoke_values).intersection(existing_values))
 
@@ -671,7 +681,7 @@ class KubeconfigGenerator(object):
                         return False
                 return True
 
-        def _build_remaining_rules_for_role(self, role_obj, revoke_norm):
+        def _build_remaining_rules_for_role(self, role_obj, revoke_norm, kubeconfig):
                 """Return (existing_rules, remaining_rules) for one role after revoke."""
                 existing_rules = role_obj.get("rules") or []
                 remaining_rules = []
@@ -724,10 +734,50 @@ class KubeconfigGenerator(object):
 
                         existing_resources = rule.get("resources") or []
                         existing_api_groups = rule.get("apiGroups") or []
-                        is_atomic_scope = (not existing_resources) or ("*" in existing_api_groups) or ("*" in existing_resources)
+
+                        # Case 3: wildcard resources with a specific API group.
+                        # Expand "*" into concrete resources so a revoke can remove
+                        # permissions from only the requested resource.
+                        if (
+                                "*" in existing_resources
+                                and len(existing_api_groups) == 1
+                                and existing_api_groups[0] != "*"
+                        ):
+                                expanded_resources = self._fetch_api_resources(existing_api_groups[0], kubeconfig)
+                                remaining_by_verbs = {}
+                                for resource in expanded_resources:
+                                        revoke_verbs = []
+                                        for matched_rule in matched_revoke_rules:
+                                                matched_resources = set(matched_rule["resources"])
+                                                resource_matches = ("*" in matched_resources 
+                                                                    or resource in matched_resources)
+                                                if not resource_matches:
+                                                        continue
+                                                revoke_verbs.extend(matched_rule["verbs"])
+                                        new_verbs = self._remove_revoked_verbs(existing_verbs, revoke_verbs)
+                                        if new_verbs:
+                                                remaining_by_verbs.setdefault(
+                                                        tuple(new_verbs),
+                                                        []
+                                                ).append(resource)
+
+                                for verbs_key, resources in sorted(remaining_by_verbs.items()):
+                                        updated_rule = dict(rule)
+                                        updated_rule["resources"] = sorted(resources)
+                                        updated_rule["verbs"] = list(verbs_key)
+                                        remaining_rules.append(updated_rule)
+
+                                continue
+
+                        # Case 4: wildcard API group or no-resource rule.
+                        # These scopes cannot be expanded safely into API groups here,
+                        # so revoke trims matching verbs from the existing rule.
+                        is_atomic_scope = (
+                                (not existing_resources)
+                                or ("*" in existing_api_groups)
+                        )
+
                         if is_atomic_scope:
-                                # Case 3: wildcard/no-resource rule.
-                                # We cannot remove just one sub-part, so trim verbs on whole rule.
                                 combined_revoke_verbs = [v for mr in matched_revoke_rules for v in mr["verbs"]]
                                 stripped_verbs = self._remove_revoked_verbs(existing_verbs, combined_revoke_verbs)
                                 if stripped_verbs:
@@ -736,7 +786,7 @@ class KubeconfigGenerator(object):
                                         remaining_rules.append(updated_rule)
                                 continue
 
-                        # Case 4: explicit resource list.
+                        # Case 5: explicit resource list.
                         # Revoke per resource so one resource change does not affect others.
                         remaining_by_verbs = {}
                         for resource in existing_resources:
@@ -800,10 +850,10 @@ class KubeconfigGenerator(object):
 
                 candidates = []
                 if update_role is not None:
-                        existing_rules, remaining_rules = self._build_remaining_rules_for_role(update_role, revoke_norm)
+                        existing_rules, remaining_rules = self._build_remaining_rules_for_role(update_role, revoke_norm, kubeconfig)
                         candidates.append((sa + "-update", update_role, existing_rules, remaining_rules))
                 if base_role is not None:
-                        existing_rules, remaining_rules = self._build_remaining_rules_for_role(base_role, revoke_norm)
+                        existing_rules, remaining_rules = self._build_remaining_rules_for_role(base_role, revoke_norm, kubeconfig)
                         candidates.append((sa, base_role, existing_rules, remaining_rules))
 
                 target = next(

--- a/provider-kubeconfig.py
+++ b/provider-kubeconfig.py
@@ -646,13 +646,21 @@ class KubeconfigGenerator(object):
                 Matching rules:
                 - For URL rules, compare only nonResourceURLs.
                 - For normal resource rules, compare apiGroups + resources.
-                - A '*' on either side means "match all" for that field.
+                - A '*' in the revoke rule matches all values.
+                - Existing wildcard grant rules are preserved unless the revoke rule also uses '*'.
                 """
                 def _overlaps(revoke_values, existing_values):
                         if not revoke_values or not existing_values:
                                 return False
-                        if "*" in revoke_values or "*" in existing_values:
+
+                        # A wildcard in the revoke rule matches all existing values.
+                        if "*" in revoke_values:
                                 return True
+
+                        # Preserve wildcard grant rules when revoking a specific permission
+                        if "*" in existing_values:
+                                return False
+
                         return bool(set(revoke_values).intersection(existing_values))
 
                 if revoke_norm_rule["nonResourceURLs"]:

--- a/tests/test_provider_kubeconfig.py
+++ b/tests/test_provider_kubeconfig.py
@@ -171,6 +171,48 @@ perms:
         )
         self.assertFalse(self.generator._revoke_targets_rule(existing, no_match))
 
+    def test_revoke_wildcard_matches_existing_specific_rule(self):
+        """A wildcard revoke target should match an existing specific rule."""
+        existing = self.generator._normalize_rule(
+            {
+                "apiGroups": ["apps"],
+                "resources": ["deployments"],
+                "verbs": ["get"],
+            }
+        )
+        revoke = self.generator._normalize_rule(
+            {
+                "apiGroups": ["apps"],
+                "resources": ["*"],
+                "verbs": ["get"],
+            }
+        )
+
+        self.assertTrue(
+            self.generator._revoke_targets_rule(existing, revoke)
+        )
+
+    def test_revoke_specific_rule_does_not_match_existing_wildcard_rule(self):
+        """A specific revoke target should not match an existing wildcard rule."""
+        existing = self.generator._normalize_rule(
+            {
+                "apiGroups": ["apps"],
+                "resources": ["*"],
+                "verbs": ["get"],
+            }
+        )
+        revoke = self.generator._normalize_rule(
+            {
+                "apiGroups": ["apps"],
+                "resources": ["deployments"],
+                "verbs": ["get"],
+            }
+        )
+
+        self.assertFalse(
+            self.generator._revoke_targets_rule(existing, revoke)
+        )
+
     def test_remove_revoked_verbs_partial(self):
         self.assertEqual(
             self.generator._remove_revoked_verbs(["get", "delete"], ["delete"]),
@@ -613,7 +655,7 @@ class TestKubeconfigIntegration(unittest.TestCase):
             )
             self.assertEqual(proc_revoke.returncode, 0, proc_revoke.stderr)
             after = self._auth_can_i(ns, sa, "create", "secrets")
-            self.assertEqual(after, "no")
+            self.assertTrue(after.startswith("no"), after)
         finally:
             _run_command("kubectl delete clusterrole " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")
             _run_command("kubectl delete clusterrolebinding " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")
@@ -794,8 +836,10 @@ class TestKubeconfigIntegration(unittest.TestCase):
                 timeout=120,
             )
             self.assertEqual(proc_revoke.returncode, 0, proc_revoke.stderr)
-            self.assertEqual(self._auth_can_i(ns, sa, "get", "pods"), "no")
-            self.assertEqual(self._auth_can_i(ns, sa, "delete", "pods"), "no")
+            get_result = self._auth_can_i(ns, sa, "get", "pods")
+            delete_result = self._auth_can_i(ns, sa, "delete", "pods")
+            self.assertTrue(get_result.startswith("no"), get_result)
+            self.assertTrue(delete_result.startswith("no"), delete_result)
         finally:
             _run_command("kubectl delete clusterrole " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")
             _run_command("kubectl delete clusterrolebinding " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")

--- a/tests/test_provider_kubeconfig.py
+++ b/tests/test_provider_kubeconfig.py
@@ -171,56 +171,74 @@ perms:
         )
         self.assertFalse(self.generator._revoke_targets_rule(existing, no_match))
 
-    def test_revoke_wildcard_matches_existing_specific_rule(self):
-        """A wildcard revoke target should match an existing specific rule."""
-        existing = self.generator._normalize_rule(
-            {
-                "apiGroups": ["apps"],
-                "resources": ["deployments"],
-                "verbs": ["get"],
-            }
-        )
-        revoke = self.generator._normalize_rule(
-            {
-                "apiGroups": ["apps"],
-                "resources": ["*"],
-                "verbs": ["get"],
-            }
-        )
-
-        self.assertTrue(
-            self.generator._revoke_targets_rule(existing, revoke)
-        )
-
-    def test_revoke_specific_rule_does_not_match_existing_wildcard_rule(self):
-        """A specific revoke target should not match an existing wildcard rule."""
-        existing = self.generator._normalize_rule(
-            {
-                "apiGroups": ["apps"],
-                "resources": ["*"],
-                "verbs": ["get"],
-            }
-        )
-        revoke = self.generator._normalize_rule(
-            {
-                "apiGroups": ["apps"],
-                "resources": ["deployments"],
-                "verbs": ["get"],
-            }
-        )
-
-        self.assertFalse(
-            self.generator._revoke_targets_rule(existing, revoke)
-        )
+    def test_fetch_api_resources_returns_resource_names(self):
+        resources = self.generator._fetch_api_resources("apps", "")
+        self.assertIn("deployments", resources)
+        self.assertIn("replicasets", resources)
 
     def test_remove_revoked_verbs_partial(self):
         self.assertEqual(
-            self.generator._remove_revoked_verbs(["get", "delete"], ["delete"]),
-            ["get"],
+            self.generator._remove_revoked_verbs(["get", "delete"], ["delete"]), ["get"],)
+
+    def test_remove_revoked_verbs_from_existing_wildcard(self):
+        """Revoking one verb from wildcard verbs keeps all other verbs."""
+        result = self.generator._remove_revoked_verbs(["*"], ["get"])
+
+        self.assertEqual(result, ["list",
+                                  "watch",
+                                  "create",
+                                  "update",
+                                  "patch",
+                                  "delete",
+                                  "deletecollection",])
+
+    def test_revoke_expands_wildcard_resources(self):
+        """Revoke expands wildcard resources and removes permission only
+        from the targeted resource.
+        """
+        role_obj = {
+                "rules": [
+                        {
+                                "apiGroups": ["apps"],
+                                "resources": ["*"],
+                                "verbs": ["*"],
+                        }
+                ]
+        }
+
+        revoke_norm = [
+                self.generator._normalize_rule(
+                        {
+                                "apiGroups": ["apps"],
+                                "resources": ["deployments"],
+                                "verbs": ["get"],
+                        }
+                )
+        ]
+
+        _, remaining_rules = (
+                self.generator._build_remaining_rules_for_role(
+                        role_obj,
+                        revoke_norm,
+                        ""
+                )
         )
 
-    def test_remove_revoked_verbs_wildcard_existing_drops_rule(self):
-        self.assertIsNone(self.generator._remove_revoked_verbs(["*"], ["get"]))
+        deployment_rule = None
+        other_resources = []
+
+        for rule in remaining_rules:
+                resources = rule.get("resources", [])
+                if "deployments" in resources:
+                        deployment_rule = rule
+                else:
+                        other_resources.extend(resources)
+
+        self.assertIsNotNone(deployment_rule)
+        self.assertNotIn("get", deployment_rule["verbs"])
+        self.assertNotIn("*", deployment_rule["verbs"])
+        self.assertIn("replicasets", other_resources)
+
 
     def test_parse_permission_rules_resource_name_substring_without_separator(self):
         """A resource key containing 'resourceName' but no '/resourceName::' separator
@@ -797,8 +815,8 @@ class TestKubeconfigIntegration(unittest.TestCase):
             if os.path.exists(permission_file):
                 os.remove(permission_file)
 
-    def test_revoke_on_wildcard_existing_verbs_drops_matching_scope_rule(self):
-        """If existing verbs include '*', revoking any verb on same scope drops that rule."""
+    def test_revoke_specific_verb_from_wildcard_verbs(self):
+        """Revoking one verb from wildcard verbs preserves all other verbs."""
         ns = "kubeplus-test-revoke-star-" + uuid.uuid4().hex[:8]
         sa = "revoke-star-sa"
         revoke_payload = {"perms": {"": [{"pods": ["get"]}]}}
@@ -839,12 +857,223 @@ class TestKubeconfigIntegration(unittest.TestCase):
             get_result = self._auth_can_i(ns, sa, "get", "pods")
             delete_result = self._auth_can_i(ns, sa, "delete", "pods")
             self.assertTrue(get_result.startswith("no"), get_result)
-            self.assertTrue(delete_result.startswith("no"), delete_result)
+            self.assertEqual(delete_result, "yes")
         finally:
             _run_command("kubectl delete clusterrole " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")
             _run_command("kubectl delete clusterrolebinding " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")
             _run_command("kubectl delete clusterrole " + sa + self.kubeconfig_flag + " 2>/dev/null")
             _run_command("kubectl delete clusterrolebinding " + sa + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete configmap " + sa + "-perms -n " + ns + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete sa " + sa + " -n " + ns + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete namespace " + ns + " --ignore-not-found --wait=false" + self.kubeconfig_flag)
+            _cleanup_script_artifacts(sa)
+            if os.path.exists(permission_file):
+                os.remove(permission_file)
+
+    def test_revoke_specific_permission_from_wildcard_grant(self):
+        """Revoking get deployments from apps/*/* preserves other permissions."""
+        ns = "test-revoke-wildcard-" + uuid.uuid4().hex[:8]
+        sa = "test-revoke-wildcard"
+        revoke_payload = {"perms": {"apps": [{"deployments": ["get"]}]}}
+        fd, permission_file = tempfile.mkstemp(suffix=".json", text=True)
+        os.close(fd)
+        with open(permission_file, "w", encoding="utf-8") as fp:
+            json.dump(revoke_payload, fp)
+        role_yaml = """
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: test-revoke-wildcard
+        rules:
+        - apiGroups:
+          - apps
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        """
+        try:
+            _run_command("kubectl create ns " + ns + self.kubeconfig_flag)
+            _run_command("kubectl create sa " + sa + " -n " + ns + self.kubeconfig_flag)
+            proc = subprocess.run(
+                ["kubectl", "apply", "-f", "-"] + self.kubeconfig_arg,
+                input=role_yaml,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            _run_command(
+                "kubectl create clusterrolebinding " + sa
+                + " --clusterrole=" + sa
+                + " --serviceaccount=" + ns + ":" + sa
+                + self.kubeconfig_flag
+            )
+            # Before revoke: wildcard grant allows both permissions.
+            self.assertEqual(self._auth_can_i(ns, sa, "get", "deployments.apps"), "yes")
+            self.assertEqual(self._auth_can_i(ns, sa, "get", "replicasets.apps"), "yes")
+            proc_revoke = subprocess.run(
+                [
+                    sys.executable,
+                    os.path.join(ROOT, SCRIPT),
+                    "revoke",
+                    ns,
+                    "-c",
+                    sa,
+                    "-p",
+                    permission_file,
+                ] + self.kubeconfig_arg,
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            self.assertEqual(proc_revoke.returncode, 0, proc_revoke.stderr)
+            # The requested permission must be revoked.
+            deployment_get = self._auth_can_i(ns, sa, "get", "deployments.apps")
+            self.assertTrue(deployment_get.startswith("no"), deployment_get)
+            # Other deployment permissions must remain.
+            self.assertEqual(self._auth_can_i(ns, sa, "list", "deployments.apps",), "yes")
+            # Other resources from the original wildcard grant must remain.
+            self.assertEqual(self._auth_can_i(ns, sa, "get", "replicasets.apps",), "yes")
+        finally:
+            _run_command("kubectl delete clusterrole " + sa + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete clusterrolebinding " + sa + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete clusterrole " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete clusterrolebinding " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete configmap " + sa + "-perms" + " -n " + ns + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete sa " + sa + " -n " + ns + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete namespace " + ns + " --ignore-not-found --wait=false" + self.kubeconfig_flag)
+            _cleanup_script_artifacts(sa)
+            if os.path.exists(permission_file):
+                os.remove(permission_file)
+
+    def test_revoke_specific_permission_from_full_wildcard_grant(self):
+        """Revoking get pods from */*/* preserves other permissions."""
+        ns = "kubeplus-test-revoke-full-wild-" + uuid.uuid4().hex[:8]
+        sa = "revoke-full-wildcard"
+        revoke_payload = {"perms": {"": [{"pods": ["get"]}]}}
+        fd, permission_file = tempfile.mkstemp(suffix=".json", text=True)
+        os.close(fd)
+        with open(permission_file, "w", encoding="utf-8") as fp:
+            json.dump(revoke_payload, fp)
+        try:
+            _run_command("kubectl create ns " + ns + self.kubeconfig_flag)
+            _run_command("kubectl create sa " + sa + " -n " + ns + self.kubeconfig_flag)
+            _run_command(
+                "kubectl create clusterrole " + sa
+                + " --verb='*' --resource='*'"
+                + self.kubeconfig_flag
+            )
+            _run_command(
+                "kubectl create clusterrolebinding " + sa
+                + " --clusterrole=" + sa
+                + " --serviceaccount=" + ns + ":" + sa
+                + self.kubeconfig_flag
+            )
+            # Before revoke, wildcard permission allows everything.
+            self.assertEqual(self._auth_can_i(ns, sa, "get", "pods"), "yes")
+            self.assertEqual(self._auth_can_i(ns, sa, "create", "pods"), "yes")
+            self.assertEqual(self._auth_can_i(ns, sa, "get", "services"), "yes")
+            proc_revoke = subprocess.run(
+                [
+                    sys.executable,
+                    os.path.join(ROOT, SCRIPT),
+                    "revoke",
+                    ns,
+                    "-c",
+                    sa,
+                    "-p",
+                    permission_file,
+                ] + self.kubeconfig_arg,
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            self.assertEqual(proc_revoke.returncode, 0, proc_revoke.stderr)
+            # Requested permission is revoked.
+            get_pods = self._auth_can_i(ns, sa, "get", "pods")
+            self.assertTrue(get_pods.startswith("no"), get_pods)
+            # Other permissions must remain.
+            self.assertEqual(self._auth_can_i(ns, sa, "create", "pods"), "yes")
+            self.assertEqual(self._auth_can_i(ns, sa, "get", "services"), "yes")
+        finally:
+            _run_command("kubectl delete clusterrole " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete clusterrolebinding " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete clusterrole " + sa + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete clusterrolebinding " + sa + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete configmap " + sa + "-perms -n " + ns + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete sa " + sa + " -n " + ns + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete namespace " + ns + " --ignore-not-found --wait=false" + self.kubeconfig_flag)
+            _cleanup_script_artifacts(sa)
+            if os.path.exists(permission_file):
+                os.remove(permission_file)
+
+    def test_revoke_all_verbs_from_specific_permission(self):
+        """Revoking * verbs from a specific permission removes that permission."""
+        ns = "kubeplus-test-revoke-all-verbs-" + uuid.uuid4().hex[:8]
+        sa = "revoke-all-verbs-sa"
+        revoke_payload = {"perms": {"apps": [{"deployments": ["*"]}]}}
+        fd, permission_file = tempfile.mkstemp(suffix=".json", text=True)
+        os.close(fd)
+        with open(permission_file, "w", encoding="utf-8") as fp:
+            json.dump(revoke_payload, fp)
+        role_yaml = """
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: revoke-all-verbs-sa
+        rules:
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+        """
+        try:
+            _run_command("kubectl create ns " + ns + self.kubeconfig_flag)
+            _run_command("kubectl create sa " + sa + " -n " + ns + self.kubeconfig_flag)
+            proc = subprocess.run(
+                ["kubectl", "apply", "-f", "-"] + self.kubeconfig_arg,
+                input=role_yaml,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            _run_command(
+                "kubectl create clusterrolebinding " + sa
+                + " --clusterrole=" + sa
+                + " --serviceaccount=" + ns + ":" + sa
+                + self.kubeconfig_flag
+            )
+            # Before revoke: get deployments is allowed.
+            self.assertEqual(self._auth_can_i(ns, sa, "get", "deployments.apps"), "yes")
+            proc_revoke = subprocess.run(
+                [
+                    sys.executable,
+                    os.path.join(ROOT, SCRIPT),
+                    "revoke",
+                    ns,
+                    "-c",
+                    sa,
+                    "-p",
+                    permission_file,
+                ] + self.kubeconfig_arg,
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            self.assertEqual(proc_revoke.returncode, 0, proc_revoke.stderr)
+            # Revoking all verbs removes the permission.
+            get_deployments = self._auth_can_i(ns, sa, "get", "deployments.apps")
+            self.assertTrue(get_deployments.startswith("no"), get_deployments)
+        finally:
+            _run_command("kubectl delete clusterrole " + sa + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete clusterrolebinding " + sa + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete clusterrole " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")
+            _run_command("kubectl delete clusterrolebinding " + sa + "-update" + self.kubeconfig_flag + " 2>/dev/null")
             _run_command("kubectl delete configmap " + sa + "-perms -n " + ns + self.kubeconfig_flag + " 2>/dev/null")
             _run_command("kubectl delete sa " + sa + " -n " + ns + self.kubeconfig_flag + " 2>/dev/null")
             _run_command("kubectl delete namespace " + ns + " --ignore-not-found --wait=false" + self.kubeconfig_flag)


### PR DESCRIPTION
## Summary

Fix RBAC revoke behavior when the existing ClusterRole contains wildcard permissions.

## Changes
- Allow specific revoke targets to match existing wildcard grant rules.
- Expand wildcard resources for specific API groups so permissions can be revoked from only the targeted resource.
- Convert wildcard verbs into explicit verbs so a specific verb can be revoked while preserving the remaining permissions.
- Preserve unrelated permissions when revoking a specific permission from wildcard RBAC rules.
- Continue treating `*` in the revoke rule as matching all applicable values.

## Validation
- Added unit tests for wildcard verb removal and wildcard resource expansion.
- Added integration tests for revoking specific permissions from `apps/*/*` and `*/*/*` grants.
- Added integration test for revoking all verbs from a specific permission.
- Verified removed permissions were revoked while required permissions remained available.
- Ran provider kubeconfig tests and the full test suite.