### PR TITLE
Update getting-started.md with KUBEPLUS_HOME instructions

### DIFF
--- a/examples/getting-started.md
+++ b/examples/getting-started.md
@@ -57,6 +57,17 @@ wp-tenant2   26s
 ```sh
 kubectl describe wordpressservices wp-tenant1 -n $KUBEPLUS_NS
 ```
+**Note: Before running commands 6 and 7**
+
+Set `KUBEPLUS_HOME` to the top-level directory where KubePlus is cloned or where the KubePlus kubectl plugins are downloaded. Do **not** include the `plugins` directory in `KUBEPLUS_HOME`.
+
+For example:
+
+```sh
+export KUBEPLUS_HOME=<path-where-you-have-cloned-kubeplus-or-where-you-have-downloaded-plugins>
+export PATH=$KUBEPLUS_HOME/plugins:$PATH
+```
+
 
 ### 6. Check Created Application Resources
 


### PR DESCRIPTION
Added note about setting KUBEPLUS_HOME before running commands.

**Note: Before running commands 6 and 7**

Set `KUBEPLUS_HOME` to the top-level directory where KubePlus is cloned or where the KubePlus kubectl plugins are downloaded. Do **not** include the `plugins` directory in `KUBEPLUS_HOME`.

For example:

```sh
export KUBEPLUS_HOME=<path-where-you-have-cloned-kubeplus-or-where-you-have-downloaded-plugins>
export PATH=$KUBEPLUS_HOME/plugins:$PATH
```
Solves #1500